### PR TITLE
Allow custom rich data types based on format

### DIFF
--- a/src/openApi/v2/parser/getMappedType.ts
+++ b/src/openApi/v2/parser/getMappedType.ts
@@ -1,32 +1,44 @@
-const TYPE_MAPPINGS = new Map<string, string>([
-    ['file', 'binary'],
-    ['any', 'any'],
-    ['object', 'any'],
-    ['array', 'any[]'],
-    ['boolean', 'boolean'],
-    ['byte', 'number'],
-    ['int', 'number'],
-    ['integer', 'number'],
-    ['float', 'number'],
-    ['double', 'number'],
-    ['short', 'number'],
-    ['long', 'number'],
-    ['number', 'number'],
-    ['char', 'string'],
-    ['date', 'string'],
-    ['date-time', 'string'],
-    ['password', 'string'],
-    ['string', 'string'],
-    ['void', 'void'],
-    ['null', 'null'],
+interface MappedType {
+    type: string;
+    isPrimitive: boolean;
+}
+
+const TYPE_MAPPINGS = new Map<string, MappedType>([
+    ['file', { type: 'binary', isPrimitive: true }],
+    ['any', { type: 'any', isPrimitive: true }],
+    ['object', { type: 'any', isPrimitive: true }],
+    ['array', { type: 'any[]', isPrimitive: true }],
+    ['boolean', { type: 'boolean', isPrimitive: true }],
+    ['byte', { type: 'number', isPrimitive: true }],
+    ['int', { type: 'number', isPrimitive: true }],
+    ['integer', { type: 'number', isPrimitive: true }],
+    ['float', { type: 'number', isPrimitive: true }],
+    ['double', { type: 'number', isPrimitive: true }],
+    ['short', { type: 'number', isPrimitive: true }],
+    ['long', { type: 'number', isPrimitive: true }],
+    ['number', { type: 'number', isPrimitive: true }],
+    ['char', { type: 'string', isPrimitive: true }],
+    ['date', { type: 'string', isPrimitive: true }],
+    ['date-time', { type: 'string', isPrimitive: true }],
+    ['password', { type: 'string', isPrimitive: true }],
+    ['string', { type: 'string', isPrimitive: true }],
+    ['void', { type: 'void', isPrimitive: true }],
+    ['null', { type: 'null', isPrimitive: true }],
+]);
+
+const FORMAT_MAPPINGS = new Map<string, MappedType>([
+    ['binary', { type: 'binary', isPrimitive: true }],
+    ['float', { type: 'number', isPrimitive: true }],
+    ['date', { type: 'string', isPrimitive: true }],
+    ['date-time', { type: 'string', isPrimitive: true }],
 ]);
 
 /**
  * Get mapped type for given type to any basic Typescript/Javascript type.
  */
-export const getMappedType = (type: string, format?: string): string | undefined => {
+export const getMappedType = (type: string, format?: string): MappedType | undefined => {
     if (format === 'binary') {
-        return 'binary';
+        return FORMAT_MAPPINGS.get(format);
     }
     return TYPE_MAPPINGS.get(type);
 };

--- a/src/openApi/v2/parser/getType.ts
+++ b/src/openApi/v2/parser/getType.ts
@@ -22,8 +22,11 @@ export const getType = (type: string = 'any', format?: string): Type => {
 
     const mapped = getMappedType(type, format);
     if (mapped) {
-        result.type = mapped;
-        result.base = mapped;
+        result.type = mapped.type;
+        result.base = mapped.type;
+        if (!mapped.isPrimitive) {
+            result.imports.push(mapped.type);
+        }
         return result;
     }
 

--- a/src/openApi/v3/parser/getMappedType.ts
+++ b/src/openApi/v3/parser/getMappedType.ts
@@ -1,32 +1,45 @@
-const TYPE_MAPPINGS = new Map<string, string>([
-    ['file', 'binary'],
-    ['any', 'any'],
-    ['object', 'any'],
-    ['array', 'any[]'],
-    ['boolean', 'boolean'],
-    ['byte', 'number'],
-    ['int', 'number'],
-    ['integer', 'number'],
-    ['float', 'number'],
-    ['double', 'number'],
-    ['short', 'number'],
-    ['long', 'number'],
-    ['number', 'number'],
-    ['char', 'string'],
-    ['date', 'string'],
-    ['date-time', 'string'],
-    ['password', 'string'],
-    ['string', 'string'],
-    ['void', 'void'],
-    ['null', 'null'],
+interface MappedType {
+    type: string;
+    isPrimitive: boolean;
+}
+
+const TYPE_MAPPINGS = new Map<string, MappedType>([
+    ['file', { type: 'binary', isPrimitive: true }],
+    ['any', { type: 'any', isPrimitive: true }],
+    ['object', { type: 'any', isPrimitive: true }],
+    ['array', { type: 'any[]', isPrimitive: true }],
+    ['boolean', { type: 'boolean', isPrimitive: true }],
+    ['byte', { type: 'number', isPrimitive: true }],
+    ['int', { type: 'number', isPrimitive: true }],
+    ['integer', { type: 'number', isPrimitive: true }],
+    ['float', { type: 'number', isPrimitive: true }],
+    ['double', { type: 'number', isPrimitive: true }],
+    ['short', { type: 'number', isPrimitive: true }],
+    ['long', { type: 'number', isPrimitive: true }],
+    ['number', { type: 'number', isPrimitive: true }],
+    ['char', { type: 'string', isPrimitive: true }],
+    ['date', { type: 'string', isPrimitive: true }],
+    ['date-time', { type: 'string', isPrimitive: true }],
+    ['password', { type: 'string', isPrimitive: true }],
+    ['string', { type: 'string', isPrimitive: true }],
+    ['void', { type: 'void', isPrimitive: true }],
+    ['null', { type: 'null', isPrimitive: true }],
+]);
+
+const FORMAT_MAPPINGS = new Map<string, MappedType>([
+    ['binary', { type: 'binary', isPrimitive: true }],
+    ['float', { type: 'number', isPrimitive: true }],
+    ['date', { type: 'string', isPrimitive: true }],
+    ['date-time', { type: 'string', isPrimitive: true }],
+    ['Big', { type: 'Big', isPrimitive: false }],
 ]);
 
 /**
  * Get mapped type for given type to any basic Typescript/Javascript type.
  */
-export const getMappedType = (type: string, format?: string): string | undefined => {
-    if (format === 'binary') {
-        return 'binary';
+export const getMappedType = (type: string, format?: string): MappedType | undefined => {
+    if (format) {
+        return FORMAT_MAPPINGS.get(format);
     }
     return TYPE_MAPPINGS.get(type);
 };

--- a/src/openApi/v3/parser/getMappedType.ts
+++ b/src/openApi/v3/parser/getMappedType.ts
@@ -31,7 +31,6 @@ const FORMAT_MAPPINGS = new Map<string, MappedType>([
     ['float', { type: 'number', isPrimitive: true }],
     ['date', { type: 'string', isPrimitive: true }],
     ['date-time', { type: 'string', isPrimitive: true }],
-    ['Big', { type: 'Big', isPrimitive: false }],
 ]);
 
 /**

--- a/src/openApi/v3/parser/getType.ts
+++ b/src/openApi/v3/parser/getType.ts
@@ -24,21 +24,25 @@ export const getType = (type: string | string[] = 'any', format?: string): Type 
     // Special case for JSON Schema spec (december 2020, page 17),
     // that allows type to be an array of primitive types...
     if (Array.isArray(type)) {
-        const joinedType = type
+        const validTypes = type
             .filter(value => value !== 'null')
             .map(value => getMappedType(value, format))
-            .filter(isDefined)
-            .join(' | ');
+            .filter(isDefined);
+        const joinedType = validTypes.map(r => r.type).join(' | ');
         result.type = joinedType;
         result.base = joinedType;
         result.isNullable = type.includes('null');
+        validTypes.filter(r => !r.isPrimitive).forEach(t => result.imports.push(t.type));
         return result;
     }
 
     const mapped = getMappedType(type, format);
     if (mapped) {
-        result.type = mapped;
-        result.base = mapped;
+        result.type = mapped.type;
+        result.base = mapped.type;
+        if (!mapped.isPrimitive) {
+            result.imports.push(mapped.type);
+        }
         return result;
     }
 


### PR DESCRIPTION
This makes it possible to utilize the `format` property to specify which
data type is to be used in the client or it should be translated
towards. Since this property is fully open ended, we are able to suit
any case we want.

The main change in this PR is starting to take into consideration this
value to discover which type the property gets translated to, before
only the actual type of the property was used (with binary being the
only `format` supported).

No custom `format` is introduced here, only the ability to easily add
them.

Both v2 and v3 parsers are modified.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>