### PR TITLE
Modify services template to fit Lune use case

### DIFF
--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -18,7 +18,11 @@ import type { {{{this}}} } from '../models/{{{this}}}';
 
 {{/if}}
 {{#notEquals @root.httpClient 'angular'}}
-import type { CancelablePromise } from '../core/CancelablePromise';
+import { ClientConfig } from '../core/ClientConfig.js'
+import { request as __request } from '../core/request.js'
+import { ApiError } from '../core/ApiError.js'
+import { AxiosInstance } from 'axios'
+import { Result } from 'ts-results-es'
 {{/notEquals}}
 {{#if @root.exportClient}}
 {{#equals @root.httpClient 'angular'}}
@@ -26,19 +30,18 @@ import { BaseHttpRequest } from '../core/BaseHttpRequest';
 {{else}}
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 {{/equals}}
-{{else}}
-import { OpenAPI } from '../core/OpenAPI';
-import { request as __request } from '../core/request';
 {{/if}}
 
 {{#equals @root.httpClient 'angular'}}
 @Injectable()
 {{/equals}}
-export class {{{name}}}{{{@root.postfix}}} {
+export abstract class {{{name}}}{{{@root.postfix}}} {
 	{{#if @root.exportClient}}
 
 	constructor(public readonly httpRequest: BaseHttpRequest) {}
 	{{else}}
+  protected abstract client: AxiosInstance
+  protected abstract config: ClientConfig
 	{{#equals @root.httpClient 'angular'}}
 
 	constructor(public readonly http: HttpClient) {}
@@ -66,8 +69,6 @@ export class {{{name}}}{{{@root.postfix}}} {
 	{{#each results}}
 	 * @returns {{{type}}} {{#if description}}{{{escapeComment description}}}{{/if}}
 	{{/each}}
-	 * @throws ApiError
-	 */
 	{{#if @root.exportClient}}
 	{{#equals @root.httpClient 'angular'}}
 	public {{{name}}}({{>parameters}}): Observable<{{>result}}> {
@@ -81,8 +82,8 @@ export class {{{name}}}{{{@root.postfix}}} {
 	public {{{name}}}({{>parameters}}): Observable<{{>result}}> {
 		return __request(OpenAPI, this.http, {
 	{{else}}
-	public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
-		return __request(OpenAPI, {
+	public {{{name}}}({{>parameters}}): Promise<Result<{{>result}}, ApiError>> {
+		return __request(this.client, this.config, {
 	{{/equals}}
 	{{/if}}
 			method: '{{{method}}}',


### PR DESCRIPTION
All the changes made in the `fix-services` step in the Makefile, have
been moved here:
- Remove CancelablePromise
- Add necessary imports
- add abstract modifier to the class
- add virtual client and config parameters to the class
- remove static modifier on the methods/endpoints
- remove throws from the documentation
- modify request to utilize the config and client provided.
- modify request response to Result

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>