### PR TITLE
Add build&test process on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build client on CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build library
+        command: npm run release
+      - name: Run unit tests
+        command: npm run test:coverage
+      - name: Run e2e tests
+        command: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build library
-        command: npm run release
+        run: npm run release
       - name: Run unit tests
-        command: npm run test:coverage
+        run: npm run test:coverage
       - name: Run e2e tests
-        command: npm run test:e2e
+        run: npm run test:e2e


### PR DESCRIPTION
To make sure things are working as expected, add the github workflow.
The original project uses circleCI, but for our case, github actions
works wonders as well and makes it unnecessary to have circleCI setup
for it.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>