### PR TITLE
Generate custom lune base client

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -1,0 +1,54 @@
+import axios, { AxiosInstance } from 'axios'
+
+import { ClientConfig } from './core/ClientConfig'
+{{#each services}}
+import { {{{name}}}Service } from './services/{{{name}}}Service.js';
+{{/each}}
+
+function applyMixins(derivedCtor: any, constructors: any[]) {
+    constructors.forEach((baseCtor) => {
+        Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {
+            Object.defineProperty(
+                derivedCtor.prototype,
+                name,
+                Object.getOwnPropertyDescriptor(baseCtor.prototype, name) || Object.create(null),
+            )
+        })
+    })
+}
+
+export class LuneClient {
+    protected client: AxiosInstance
+    protected config: ClientConfig
+
+    constructor(apiKey: string, baseUrl: string = 'https://api.lune.co', apiVersion: string = '1') {
+        this.config = {
+            BASE_URL: `${baseUrl}/v{api-version}`,
+            VERSION: apiVersion,
+            BEARER_TOKEN: apiKey,
+        }
+        this.client = axios.create()
+    }
+}
+
+applyMixins(LuneClient, [
+    {{#if services}}
+    {{#each services}}
+    {{{name}}}Service,
+    {{/each}}
+    {{/if}}
+])
+
+// eslint-disable-next-line no-redeclare -- mixins require same name
+export interface LuneClient extends
+    {{#each services}}
+    {{{name}}}Service{{#unless @last}},{{/unless}}
+    {{/each}} {}
+
+{{#each models}}
+export type { {{{name}}} } from './models/{{{name}}}.js';
+{{/each}}
+
+{{#each services}}
+export { {{{name}}}Service } from './services/{{{name}}}Service.js';
+{{/each}}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -56,6 +56,7 @@ import templateExportModel from '../templates/exportModel.hbs';
 import templateExportSchema from '../templates/exportSchema.hbs';
 import templateExportService from '../templates/exportService.hbs';
 import templateIndex from '../templates/index.hbs';
+import templateLuneClient from '../templates/luneClient.hbs';
 import partialBase from '../templates/partials/base.hbs';
 import partialExportComposition from '../templates/partials/exportComposition.hbs';
 import partialExportEnum from '../templates/partials/exportEnum.hbs';
@@ -88,6 +89,7 @@ import { registerHandlebarHelpers } from './registerHandlebarHelpers';
 export interface Templates {
     index: Handlebars.TemplateDelegate;
     client: Handlebars.TemplateDelegate;
+    luneClient: Handlebars.TemplateDelegate;
     exports: {
         model: Handlebars.TemplateDelegate;
         schema: Handlebars.TemplateDelegate;
@@ -120,6 +122,7 @@ export const registerHandlebarTemplates = (root: {
     const templates: Templates = {
         index: Handlebars.template(templateIndex),
         client: Handlebars.template(templateClient),
+        luneClient: Handlebars.template(templateLuneClient),
         exports: {
             model: Handlebars.template(templateExportModel),
             schema: Handlebars.template(templateExportSchema),

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -19,6 +19,7 @@ describe('writeClient', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -13,6 +13,7 @@ import { writeClientIndex } from './writeClientIndex';
 import { writeClientModels } from './writeClientModels';
 import { writeClientSchemas } from './writeClientSchemas';
 import { writeClientServices } from './writeClientServices';
+import { writeLuneClient } from './writeLuneClient';
 
 /**
  * Write our OpenAPI client, using the given templates at the given output
@@ -53,6 +54,7 @@ export const writeClient = async (
     const outputPathModels = resolve(outputPath, 'models');
     const outputPathSchemas = resolve(outputPath, 'schemas');
     const outputPathServices = resolve(outputPath, 'services');
+    const outputLuneClient = resolve(outputPath);
 
     if (!isSubDirectory(process.cwd(), output)) {
         throw new Error(`Output folder is not a subdirectory of the current working directory`);
@@ -112,4 +114,6 @@ export const writeClient = async (
             clientName
         );
     }
+
+    await writeLuneClient(client, templates, outputLuneClient);
 };

--- a/src/utils/writeClientClass.spec.ts
+++ b/src/utils/writeClientClass.spec.ts
@@ -19,6 +19,7 @@ describe('writeClientClass', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClientCore.spec.ts
+++ b/src/utils/writeClientCore.spec.ts
@@ -19,6 +19,7 @@ describe('writeClientCore', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -17,6 +17,7 @@ describe('writeClientIndex', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -32,6 +32,7 @@ describe('writeClientModels', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClientSchemas.spec.ts
+++ b/src/utils/writeClientSchemas.spec.ts
@@ -32,6 +32,7 @@ describe('writeClientSchemas', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -20,6 +20,7 @@ describe('writeClientServices', () => {
         const templates: Templates = {
             index: () => 'index',
             client: () => 'client',
+            luneClient: () => 'luneClient',
             exports: {
                 model: () => 'model',
                 schema: () => 'schema',

--- a/src/utils/writeLuneClient.ts
+++ b/src/utils/writeLuneClient.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'path';
+
+import type { Client } from '../client/interfaces/Client';
+import { writeFile } from './fileSystem';
+import { Templates } from './registerHandlebarTemplates';
+import { sortModelsByName } from './sortModelsByName';
+import { sortServicesByName } from './sortServicesByName';
+
+/**
+ * Generate our custom Lune client file. This is the main file used to export everything and that defines
+ * how to use our client. It re exports all models and services so they become available at the base level.
+ * @param client Client object, containing, models, schemas and services
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ */
+export const writeLuneClient = async (client: Client, templates: Templates, outputPath: string): Promise<void> => {
+    const templateResult = templates.luneClient({
+        models: sortModelsByName(client.models),
+        services: sortServicesByName(client.services),
+    });
+
+    await writeFile(resolve(outputPath, 'luneClient.ts'), templateResult);
+};


### PR DESCRIPTION
This is an exact replica of:
https://github.com/lune-climate/openapi-typescript-codegen/pull/4

The base of the PR was wrong hence it wasn't sent to master. I think
there's probably a config setting to make it automatically change so
I'll investigate that, but for now, replicate the changes to master as
well.

Here's the previous PR description:
```
This fully generates a new file whenever a generation operation is
performed.
The client has the name `luneClient.ts` and it's meant to be used by
https://github.com/lune-climate/lune-ts as a starting point for the
creation of the final client. This is highly custom behaviour for
us (Lune) to make the creation of our npm package easier.

The introduced file is a replica of the current final client as
generated by `lune-ts`. This makes it easier for us to generate the
final client in the package without extra `sed | cat` operations and
makes it a lot clearer.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>
```