### PR TITLE
Fix luneClient template

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -53,7 +53,7 @@ export class LuneClient {
         })
 
         // Convert to camelCase when receiving request
-        client.interceptors.response.use(
+        this.client.interceptors.response.use(
             (response) => camelCaseKeys(response.data, { deep: true }),
             (error) => Promise.reject(error.response),
         )


### PR DESCRIPTION
There was a missing reference to `this` since the client is part of the
class.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>