### PR TITLE
Fix luneClient template

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -1,5 +1,4 @@
 import axios, { AxiosInstance } from 'axios'
-import snakeCaseKeys from 'snakecase-keys'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig'
@@ -37,26 +36,10 @@ export class LuneClient {
         }
         this.client = axios.create()
 
-        // Convert to snake case when sending request
-        this.client.interceptors.request.use((req) => {
-            const requestCopy = { ...req }
-
-            if (requestCopy.params) {
-                requestCopy.params = snakeCaseKeys(req.params, { deep: true })
-            }
-
-            if (requestCopy.data) {
-                requestCopy.data = snakeCaseKeys(req.data, { deep: true })
-          }
-
-          return requestCopy
-        })
-
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use(
-            (response) => camelCaseKeys(response.data, { deep: true }),
-            (error) => Promise.reject(error.response),
-        )
+        this.client.interceptors.response.use((response) => {
+            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        })
     }
 
     public setAccount(accountId: string) {


### PR DESCRIPTION
The conversion to snake_case when sending the request is better suited
to be done when we create the body to send. This prevents having to
decode something already encoded in JSON just to make the conversion.
Additionally, the response conversion we want to fully maintain the same
format in both success and error, so simply fix that as well.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>