### PR TITLE
Add companion enum when using union types

### DIFF
--- a/src/templates/exportModel.hbs
+++ b/src/templates/exportModel.hbs
@@ -18,6 +18,7 @@ import type { {{{this}}} } from './{{{this}}}';
 {{else equals export 'enum'}}
 {{#if @root.useUnionTypes}}
 {{>exportType}}
+{{>exportCompanionEnum}}
 {{else}}
 {{>exportEnum}}
 {{/if}}

--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -62,7 +62,12 @@ export interface LuneClient extends
     {{/each}} {}
 
 {{#each models}}
+{{#equals export 'enum'}}
 export type { {{{name}}} } from './models/{{{name}}}.js';
+export { {{{name}}}Enum } from './models/{{{name}}}.js';
+{{else}}
+export type { {{{name}}} } from './models/{{{name}}}.js';
+{{/equals}}
 {{/each}}
 
 {{#each services}}

--- a/src/templates/partials/exportCompanionEnum.hbs
+++ b/src/templates/partials/exportCompanionEnum.hbs
@@ -1,0 +1,19 @@
+{{#if description}}
+/**
+ * {{{escapeComment description}}}
+ */
+{{/if}}
+export enum {{{name}}}Enum {
+	{{#each enum}}
+	{{#if description}}
+	/**
+	 * {{{escapeComment description}}}
+	 */
+	{{/if}}
+	{{#containsSpaces name}}
+	'{{{name}}}' = {{{value}}},
+	{{else}}
+	{{{name}}} = {{{value}}},
+	{{/containsSpaces}}
+	{{/each}}
+}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -60,6 +60,7 @@ import templateLuneClient from '../templates/luneClient.hbs';
 import partialBase from '../templates/partials/base.hbs';
 import partialExportComposition from '../templates/partials/exportComposition.hbs';
 import partialExportEnum from '../templates/partials/exportEnum.hbs';
+import partialExportCompanionEnum from '../templates/partials/exportCompanionEnum.hbs';
 import partialExportInterface from '../templates/partials/exportInterface.hbs';
 import partialExportType from '../templates/partials/exportType.hbs';
 import partialHeader from '../templates/partials/header.hbs';
@@ -142,6 +143,7 @@ export const registerHandlebarTemplates = (root: {
 
     // Partials for the generations of the models, services, etc.
     Handlebars.registerPartial('exportEnum', Handlebars.template(partialExportEnum));
+    Handlebars.registerPartial('exportCompanionEnum', Handlebars.template(partialExportCompanionEnum));
     Handlebars.registerPartial('exportInterface', Handlebars.template(partialExportInterface));
     Handlebars.registerPartial('exportComposition', Handlebars.template(partialExportComposition));
     Handlebars.registerPartial('exportType', Handlebars.template(partialExportType));

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -776,8 +776,11 @@ export type { DictionaryWithReference } from './models/DictionaryWithReference.j
 export type { DictionaryWithString } from './models/DictionaryWithString.js';
 export type { EnumFromDescription } from './models/EnumFromDescription.js';
 export type { EnumWithExtensions } from './models/EnumWithExtensions.js';
+export { EnumWithExtensionsEnum } from './models/EnumWithExtensions.js';
 export type { EnumWithNumbers } from './models/EnumWithNumbers.js';
+export { EnumWithNumbersEnum } from './models/EnumWithNumbers.js';
 export type { EnumWithStrings } from './models/EnumWithStrings.js';
+export { EnumWithStringsEnum } from './models/EnumWithStrings.js';
 export type { ModelThatExtends } from './models/ModelThatExtends.js';
 export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends.js';
 export type { ModelWithArray } from './models/ModelWithArray.js';
@@ -4048,8 +4051,11 @@ export type { DictionaryWithReference } from './models/DictionaryWithReference.j
 export type { DictionaryWithString } from './models/DictionaryWithString.js';
 export type { EnumFromDescription } from './models/EnumFromDescription.js';
 export type { EnumWithExtensions } from './models/EnumWithExtensions.js';
+export { EnumWithExtensionsEnum } from './models/EnumWithExtensions.js';
 export type { EnumWithNumbers } from './models/EnumWithNumbers.js';
+export { EnumWithNumbersEnum } from './models/EnumWithNumbers.js';
 export type { EnumWithStrings } from './models/EnumWithStrings.js';
+export { EnumWithStringsEnum } from './models/EnumWithStrings.js';
 export type { File } from './models/File.js';
 export type { ModelCircle } from './models/ModelCircle.js';
 export type { ModelSquare } from './models/ModelSquare.js';


### PR DESCRIPTION
This makes it that when we're using union types, we also add an enum
with the possible values to the models. This is necessary for Lune's
use case since union types cannot generate a list of values to
iterate through them, making things like get all values of this type
impossible. This is a use case we have in multiple places, for example
fetching all `CabinClass`. The import has also been added to the
`luneClient` whenever neededs: if the model is an enum and we're using
union types.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>