### PR TITLE
Fix luneClient model reexports

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -62,7 +62,15 @@ export interface LuneClient extends
     {{/each}} {}
 
 {{#each models}}
+{{#if @root.useUnionTypes}}
 export type { {{{name}}} } from './models/{{{name}}}.js';
+{{else if enum}}
+export { {{{name}}} } from './models/{{{name}}}.js';
+{{else if enums}}
+export { {{{name}}} } from './models/{{{name}}}.js';
+{{else}}
+export type { {{{name}}} } from './models/{{{name}}}.js';
+{{/if}}
 {{/each}}
 
 {{#each services}}

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -775,9 +775,9 @@ export type { DictionaryWithProperties } from './models/DictionaryWithProperties
 export type { DictionaryWithReference } from './models/DictionaryWithReference.js';
 export type { DictionaryWithString } from './models/DictionaryWithString.js';
 export type { EnumFromDescription } from './models/EnumFromDescription.js';
-export type { EnumWithExtensions } from './models/EnumWithExtensions.js';
-export type { EnumWithNumbers } from './models/EnumWithNumbers.js';
-export type { EnumWithStrings } from './models/EnumWithStrings.js';
+export { EnumWithExtensions } from './models/EnumWithExtensions.js';
+export { EnumWithNumbers } from './models/EnumWithNumbers.js';
+export { EnumWithStrings } from './models/EnumWithStrings.js';
 export type { ModelThatExtends } from './models/ModelThatExtends.js';
 export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends.js';
 export type { ModelWithArray } from './models/ModelWithArray.js';
@@ -786,8 +786,8 @@ export type { ModelWithCircularReference } from './models/ModelWithCircularRefer
 export type { ModelWithDictionary } from './models/ModelWithDictionary.js';
 export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports.js';
 export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties.js';
-export type { ModelWithEnum } from './models/ModelWithEnum.js';
-export type { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription.js';
+export { ModelWithEnum } from './models/ModelWithEnum.js';
+export { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription.js';
 export type { ModelWithInteger } from './models/ModelWithInteger.js';
 export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums.js';
 export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties.js';
@@ -4047,9 +4047,9 @@ export type { DictionaryWithProperties } from './models/DictionaryWithProperties
 export type { DictionaryWithReference } from './models/DictionaryWithReference.js';
 export type { DictionaryWithString } from './models/DictionaryWithString.js';
 export type { EnumFromDescription } from './models/EnumFromDescription.js';
-export type { EnumWithExtensions } from './models/EnumWithExtensions.js';
-export type { EnumWithNumbers } from './models/EnumWithNumbers.js';
-export type { EnumWithStrings } from './models/EnumWithStrings.js';
+export { EnumWithExtensions } from './models/EnumWithExtensions.js';
+export { EnumWithNumbers } from './models/EnumWithNumbers.js';
+export { EnumWithStrings } from './models/EnumWithStrings.js';
 export type { File } from './models/File.js';
 export type { ModelCircle } from './models/ModelCircle.js';
 export type { ModelSquare } from './models/ModelSquare.js';
@@ -4061,8 +4061,8 @@ export type { ModelWithCircularReference } from './models/ModelWithCircularRefer
 export type { ModelWithDictionary } from './models/ModelWithDictionary.js';
 export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports.js';
 export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties.js';
-export type { ModelWithEnum } from './models/ModelWithEnum.js';
-export type { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription.js';
+export { ModelWithEnum } from './models/ModelWithEnum.js';
+export { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription.js';
 export type { ModelWithInteger } from './models/ModelWithInteger.js';
 export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums.js';
 export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties.js';


### PR DESCRIPTION
The current model reexports assumed the export was done only with union
types. This might not be the case, so deal with all possible cases.
This is an exact copy as to how the `index` file handles these exports.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>