### PR TITLE
Rework methods interface

### DIFF
--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -1,3 +1,4 @@
+import { Model } from '../../../client/interfaces/Model';
 import type { Operation } from '../../../client/interfaces/Operation';
 import { OperationParameter } from '../../../client/interfaces/OperationParameter';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
@@ -104,6 +105,48 @@ export const getOperation = (
     }
 
     operation.parameters = operation.parameters.sort(sortByRequired);
+    // Add an options object parameter for options on the methods themselves. Currently allow an account
+    // override that can use `Lune-Account` header to override target account on a per endpoint basis.
+    operation.parameters.push({
+        in: 'query',
+        export: 'interface',
+        prop: 'options',
+        name: 'options',
+        type: 'any',
+        base: 'any',
+        template: null,
+        link: null,
+        description: 'Additional operation options',
+        default: undefined,
+        isDefinition: false,
+        isReadOnly: false,
+        isRequired: false,
+        isNullable: false,
+        imports: [],
+        enum: [],
+        enums: [],
+        properties: [
+            {
+                export: 'generic',
+                name: 'accountId',
+                type: 'string',
+                base: 'string',
+                template: null,
+                link: null,
+                description: 'Account Id to be used to perform the API call',
+                default: undefined,
+                isDefinition: false,
+                isReadOnly: false,
+                isRequired: false,
+                isNullable: false,
+                imports: [],
+                enum: [],
+                enums: [],
+                properties: [],
+            } as Model,
+        ],
+        mediaType: null,
+    });
 
     return operation;
 };

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -1,3 +1,4 @@
+import { Model } from '../../../client/interfaces/Model';
 import type { Operation } from '../../../client/interfaces/Operation';
 import { OperationParameter } from '../../../client/interfaces/OperationParameter';
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
@@ -13,7 +14,7 @@ import { getOperationResponses } from './getOperationResponses';
 import { getOperationResults } from './getOperationResults';
 import { getRef } from './getRef';
 import { getServiceName } from './getServiceName';
-import { sortByRequired } from './sortByRequired';
+import { sortByRequired, sortModelByRequired } from './sortByRequired';
 
 export const getOperation = (
     openApi: OpenApi,
@@ -48,38 +49,43 @@ export const getOperation = (
         responseHeader: null,
     };
 
+    // We want to treat query parameters and body request as a single object with all the parameters
+    // inside. This allows for better and more concise usage (named parameters) for our clients. We are
+    // aware this makes names between query an request parameters cannot be duplicate, which is a
+    // possibility. However, we currently don't have this case and agreed on avoiding in the future
+    // for the sake of improving our clients interface. Extract the query params and the request body
+    // (if it exists) and join them accordingly in a new dataParameter object.
+    const dataParameter: OperationParameter = {
+        // value here is actually ignore, we just need to provide a valid one
+        in: 'query',
+        export: 'interface',
+        prop: 'data',
+        name: 'data',
+        type: 'any',
+        base: 'any',
+        template: null,
+        link: null,
+        description: null,
+        default: undefined,
+        isDefinition: false,
+        isReadOnly: false,
+        isRequired: false,
+        isNullable: false,
+        imports: [],
+        enum: [],
+        enums: [],
+        properties: [],
+        mediaType: null,
+    };
+
     // Parse the operation parameters (path, query, body, etc).
     if (op.parameters) {
         const parameters = getOperationParameters(openApi, op.parameters);
 
-        // We want to treat query parameters as a single object with all the parameters inside. This
-        // allows for better and more concise usage (named parameters). For that, extract them from
-        // the parameters, create a fake operation for them and addem them individually as single object
         const queryParams = parameters.parameters.filter(p => p.in === 'query');
         if (queryParams.length !== 0) {
-            const queryParamsObject: OperationParameter = {
-                in: 'query',
-                export: 'interface',
-                prop: 'queryParams',
-                name: 'queryParams',
-                type: 'any',
-                base: 'any',
-                template: null,
-                link: null,
-                description: null,
-                default: undefined,
-                isDefinition: false,
-                isReadOnly: false,
-                isRequired: !!queryParams.find(p => p.isRequired),
-                isNullable: !!!queryParams.find(p => !p.isNullable),
-                imports: [],
-                enum: [],
-                enums: [],
-                properties: queryParams,
-                mediaType: null,
-            };
-
-            operation.parameters.push(queryParamsObject);
+            dataParameter.properties.push(...queryParams);
+            dataParameter.isRequired = !!queryParams.find(p => p.isRequired);
         }
 
         const newParams = parameters.parameters.filter(p => p.in !== 'query');
@@ -97,8 +103,9 @@ export const getOperation = (
         const requestBodyDef = getRef<OpenApiRequestBody>(openApi, op.requestBody);
         const requestBody = getOperationRequestBody(openApi, requestBodyDef);
         operation.imports.push(...requestBody.imports);
-        operation.parameters.push(requestBody);
         operation.parametersBody = requestBody;
+        dataParameter.properties.push(...requestBody.properties);
+        dataParameter.isRequired = requestBody.isRequired ? true : dataParameter.isRequired;
     }
 
     // Parse the operation responses.
@@ -114,7 +121,54 @@ export const getOperation = (
         });
     }
 
+    if (dataParameter.properties.length !== 0) {
+        operation.parameters.push(dataParameter);
+        dataParameter.properties = dataParameter.properties.sort(sortModelByRequired);
+    }
     operation.parameters = operation.parameters.sort(sortByRequired);
+
+    // Add an options object parameter for options on the methods themselves. Currently allow an account
+    // override that can use `Lune-Account` header to override target account on a per endpoint basis.
+    operation.parameters.push({
+        in: 'query',
+        export: 'interface',
+        prop: 'options',
+        name: 'options',
+        type: 'any',
+        base: 'any',
+        template: null,
+        link: null,
+        description: 'Additional operation options',
+        default: undefined,
+        isDefinition: false,
+        isReadOnly: false,
+        isRequired: false,
+        isNullable: false,
+        imports: [],
+        enum: [],
+        enums: [],
+        properties: [
+            {
+                export: 'generic',
+                name: 'accountId',
+                type: 'string',
+                base: 'string',
+                template: null,
+                link: null,
+                description: 'Account Id to be used to perform the API call',
+                default: undefined,
+                isDefinition: false,
+                isReadOnly: false,
+                isRequired: false,
+                isNullable: false,
+                imports: [],
+                enum: [],
+                enums: [],
+                properties: [],
+            } as Model,
+        ],
+        mediaType: null,
+    });
 
     return operation;
 };

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -65,7 +65,7 @@ export const getOperation = (
         base: 'any',
         template: null,
         link: null,
-        description: null,
+        description: 'Request data',
         default: undefined,
         isDefinition: false,
         isReadOnly: false,

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -105,6 +105,11 @@ export const getOperation = (
         operation.imports.push(...requestBody.imports);
         operation.parametersBody = requestBody;
         dataParameter.properties.push(...requestBody.properties);
+        // if the requestBody is an array, there are no properties to showcase. We instead want to
+        // use the whole model as the parameter
+        if (requestBody.export === 'array') {
+            dataParameter.properties.push(requestBody);
+        }
         dataParameter.isRequired = requestBody.isRequired ? true : dataParameter.isRequired;
     }
 

--- a/src/openApi/v3/parser/getOperationRequestBody.ts
+++ b/src/openApi/v3/parser/getOperationRequestBody.ts
@@ -6,6 +6,7 @@ import { getContent } from './getContent';
 import { getModel } from './getModel';
 import { getModelComposition } from './getModelComposition';
 import { getModelProperties } from './getModelProperties';
+import { getOperationParameter } from './getOperationParameter';
 import { getRef } from './getRef';
 import { getType } from './getType';
 
@@ -51,11 +52,33 @@ export const getOperationRequestBody = (openApi: OpenApi, body: OpenApiRequestBo
                 const reference = getRef(openApi, content.schema);
                 const model = getModel(openApi, reference, true, definitionType.base);
 
+                requestBody.name = model.name;
+                requestBody.export = model.export;
                 requestBody.type = model.type;
                 requestBody.base = model.base;
                 requestBody.template = model.template;
-                requestBody.properties.push(...model.properties);
+                requestBody.link = model.link;
+                requestBody.isReadOnly = model.isReadOnly;
+                requestBody.isRequired = requestBody.isRequired || model.isRequired;
+                requestBody.isNullable = requestBody.isNullable || model.isNullable;
+                requestBody.format = model.format;
+                requestBody.maximum = model.maximum;
+                requestBody.exclusiveMaximum = model.exclusiveMaximum;
+                requestBody.minimum = model.minimum;
+                requestBody.exclusiveMinimum = model.exclusiveMinimum;
+                requestBody.multipleOf = model.multipleOf;
+                requestBody.maxLength = model.maxLength;
+                requestBody.minLength = model.minLength;
+                requestBody.maxItems = model.maxItems;
+                requestBody.minItems = model.minItems;
+                requestBody.uniqueItems = model.uniqueItems;
+                requestBody.maxProperties = model.maxProperties;
+                requestBody.minProperties = model.minProperties;
+                requestBody.pattern = getPattern(model.pattern);
                 requestBody.imports.push(...model.imports);
+                requestBody.enum.push(...model.enum);
+                requestBody.enums.push(...model.enums);
+                requestBody.properties.push(...model.properties);
                 return requestBody;
             } else {
                 const model = getModel(openApi, content.schema);

--- a/src/openApi/v3/parser/sortByRequired.ts
+++ b/src/openApi/v3/parser/sortByRequired.ts
@@ -1,6 +1,15 @@
+import { Model } from '../../../client/interfaces/Model';
 import type { OperationParameter } from '../../../client/interfaces/OperationParameter';
 
 export const sortByRequired = (a: OperationParameter, b: OperationParameter): number => {
+    const aNeedsValue = a.isRequired && a.default === undefined;
+    const bNeedsValue = b.isRequired && b.default === undefined;
+    if (aNeedsValue && !bNeedsValue) return -1;
+    if (bNeedsValue && !aNeedsValue) return 1;
+    return 0;
+};
+
+export const sortModelByRequired = (a: Model, b: Model): number => {
     const aNeedsValue = a.isRequired && a.default === undefined;
     const bNeedsValue = b.isRequired && b.default === undefined;
     if (aNeedsValue && !bNeedsValue) return -1;

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -113,7 +113,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#if parametersQuery}}
 			query: {
 				{{#each parametersQuery}}
-				'{{{prop}}}': data.{{{name}}},
+				'{{{prop}}}': data?.{{{name}}},
 				{{/each}}
 			},
 			{{/if}}
@@ -131,7 +131,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#equals parametersBody.in 'body'}}
 			body: {
 				{{#each parametersBody.properties}}
-				'{{{name}}}': data.{{{name}}},
+				'{{{name}}}': data?.{{{name}}},
 				{{/each}}
 			},
 			{{/equals}}

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -84,7 +84,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 		return __request(OpenAPI, this.http, {
 	{{else}}
 	public {{{name}}}({{>parameters}}): Promise<Result<{{>result}}, ApiError>> {
-		return __request(this.client, this.config, options, {
+		return __request(this.client, this.config, options || {}, {
 	{{/equals}}
 	{{/if}}
 			method: '{{{method}}}',

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -113,7 +113,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#if parametersQuery}}
 			query: {
 				{{#each parametersQuery}}
-				'{{{prop}}}': data?.{{{name}}},
+				'{{{prop}}}': data?.{{{camelCase name}}},
 				{{/each}}
 			},
 			{{/if}}
@@ -131,7 +131,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#equals parametersBody.in 'body'}}
 			body: {
 				{{#each parametersBody.properties}}
-				'{{{name}}}': data?.{{{name}}},
+				'{{{name}}}': data?.{{{camelCase name}}},
 				{{/each}}
 			},
 			{{/equals}}

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -135,9 +135,10 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 				'{{{name}}}': data?.{{{camelCase name}}},
 				{{/each}}
 			},
-			{{/if}}
+			{{else}}
 			{{#if parametersBody.export}}
 			body: data?.{{{camelCase parametersBody.name}}},
+			{{/if}}
 			{{/if}}
 			{{/equals}}
 			{{#if parametersBody.mediaType}}

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -84,7 +84,7 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 		return __request(OpenAPI, this.http, {
 	{{else}}
 	public {{{name}}}({{>parameters}}): Promise<Result<{{>result}}, ApiError>> {
-		return __request(this.client, this.config, {
+		return __request(this.client, this.config, options, {
 	{{/equals}}
 	{{/if}}
 			method: '{{{method}}}',
@@ -111,7 +111,11 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			},
 			{{/if}}
 			{{#if parametersQuery}}
-			query: queryParams,
+			query: {
+				{{#each parametersQuery}}
+				'{{{prop}}}': data.{{{name}}},
+				{{/each}}
+			},
 			{{/if}}
 			{{#if parametersForm}}
 			formData: {
@@ -125,7 +129,11 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			formData: {{{parametersBody.name}}},
 			{{/equals}}
 			{{#equals parametersBody.in 'body'}}
-			body: {{{parametersBody.name}}},
+			body: {
+				{{#each parametersBody.properties}}
+				'{{{name}}}': data.{{{name}}},
+				{{/each}}
+			},
 			{{/equals}}
 			{{#if parametersBody.mediaType}}
 			mediaType: '{{{parametersBody.mediaType}}}',

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -129,11 +129,16 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			formData: {{{parametersBody.name}}},
 			{{/equals}}
 			{{#equals parametersBody.in 'body'}}
+			{{#if parametersBody.properties}}
 			body: {
 				{{#each parametersBody.properties}}
 				'{{{name}}}': data?.{{{camelCase name}}},
 				{{/each}}
 			},
+			{{/if}}
+			{{#if parametersBody.export}}
+			body: data?.{{{camelCase parametersBody.name}}},
+			{{/if}}
 			{{/equals}}
 			{{#if parametersBody.mediaType}}
 			mediaType: '{{{parametersBody.mediaType}}}',

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2420,6 +2420,7 @@ export abstract class CollectionFormatService {
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      */
     public collectionFormat(
         queryParams: {
@@ -2444,11 +2445,23 @@ export abstract class CollectionFormatService {
              */
             parameterArrayMulti: Array<string>;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
-            query: queryParams,
+            query: {
+                'parameterArrayCSV': data.parameterArrayCsv,
+                'parameterArraySSV': data.parameterArraySsv,
+                'parameterArrayTSV': data.parameterArrayTsv,
+                'parameterArrayPipes': data.parameterArrayPipes,
+                'parameterArrayMulti': data.parameterArrayMulti,
+            },
         });
     }
 
@@ -2473,6 +2486,7 @@ export abstract class ComplexService {
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      * @returns ModelWithString Successful response
      */
     public complexTypes(
@@ -2492,11 +2506,20 @@ export abstract class ComplexService {
              */
             parameterReference: ModelWithString;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<Array<ModelWithString>, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
-            query: queryParams,
+            query: {
+                'parameterObject': data.parameterObject,
+                'parameterReference': data.parameterReference,
+            },
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -2522,9 +2545,17 @@ export abstract class DefaultService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public serviceWithEmptyTag(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public serviceWithEmptyTag(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
         });
@@ -2551,6 +2582,7 @@ export abstract class DefaultsService {
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      */
     public callWithDefaultParameters(
         queryParams: {
@@ -2575,16 +2607,29 @@ export abstract class DefaultsService {
              */
             parameterModel: ModelWithString;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterString': data.parameterString,
+                'parameterNumber': data.parameterNumber,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterEnum': data.parameterEnum,
+                'parameterModel': data.parameterModel,
+            },
         });
     }
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      */
     public callWithDefaultOptionalParameters(
         queryParams?: {
@@ -2609,16 +2654,29 @@ export abstract class DefaultsService {
              */
             parameterModel: ModelWithString;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterString': data.parameterString,
+                'parameterNumber': data.parameterNumber,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterEnum': data.parameterEnum,
+                'parameterModel': data.parameterModel,
+            },
         });
     }
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      */
     public callToTestOrderOfParams(
         queryParams: {
@@ -2655,11 +2713,26 @@ export abstract class DefaultsService {
              */
             parameterStringNullableWithDefault: string | null;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterOptionalStringWithDefault': data.parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': data.parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': data.parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': data.parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': data.parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': data.parameterStringWithNoDefault,
+                'parameterStringNullableWithNoDefault': data.parameterStringNullableWithNoDefault,
+                'parameterStringNullableWithDefault': data.parameterStringNullableWithDefault,
+            },
         });
     }
 
@@ -2682,6 +2755,7 @@ export abstract class DescriptionsService {
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      */
     public callWithDescriptions(
         queryParams?: {
@@ -2713,11 +2787,24 @@ export abstract class DescriptionsService {
              */
             parameterWithReservedCharacters?: string;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
-            query: queryParams,
+            query: {
+                'parameterWithBreaks': data.parameterWithBreaks,
+                'parameterWithBackticks': data.parameterWithBackticks,
+                'parameterWithSlashes': data.parameterWithSlashes,
+                'parameterWithExpressionPlaceholders': data.parameterWithExpressionPlaceholders,
+                'parameterWithQuotes': data.parameterWithQuotes,
+                'parameterWithReservedCharacters': data.parameterWithReservedCharacters,
+            },
         });
     }
 
@@ -2739,36 +2826,68 @@ export abstract class DuplicateService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName1(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName1(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName2(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName2(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName3(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName3(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
         });
@@ -2793,6 +2912,7 @@ export abstract class ErrorService {
 
     /**
      * @param queryParams
+     * @param options Additional operation options
      * @returns any Custom message: Successful response
      */
     public testErrorCode(
@@ -2802,11 +2922,19 @@ export abstract class ErrorService {
              */
             status: string;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<any, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/error',
-            query: queryParams,
+            query: {
+                'status': data.status,
+            },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
                 501: \`Custom message: Not Implemented\`,
@@ -2834,10 +2962,18 @@ export abstract class HeaderService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns string Successful response
      */
-    public callWithResultFromHeader(): Promise<Result<string, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithResultFromHeader(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<string, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
@@ -2866,20 +3002,36 @@ export abstract class MultipleTags1Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyA(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyA(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -2903,20 +3055,36 @@ export abstract class MultipleTags2Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyA(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyA(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -2940,10 +3108,18 @@ export abstract class MultipleTags3Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -2967,10 +3143,18 @@ export abstract class NoContentService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public callWithNoContentResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithNoContentResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
         });
@@ -2999,6 +3183,7 @@ export abstract class ParametersService {
      * @param parameterForm This is the parameter that goes into the form data
      * @param parameterBody This is the parameter that is sent as request body
      * @param parameterPath This is the parameter that goes into the path
+     * @param options Additional operation options
      */
     public callWithParameters(
         queryParams: {
@@ -3011,8 +3196,14 @@ export abstract class ParametersService {
         parameterForm: string,
         parameterBody: string,
         parameterPath: string,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
@@ -3021,11 +3212,14 @@ export abstract class ParametersService {
             headers: {
                 'parameterHeader': parameterHeader,
             },
-            query: queryParams,
+            query: {
+                'parameterQuery': data.parameterQuery,
+            },
             formData: {
                 'parameterForm': parameterForm,
             },
-            body: parameterBody,
+            body: {
+            },
         });
     }
 
@@ -3037,6 +3231,7 @@ export abstract class ParametersService {
      * @param parameterPath1 This is the parameter that goes into the path
      * @param parameterPath2 This is the parameter that goes into the path
      * @param parameterPath3 This is the parameter that goes into the path
+     * @param options Additional operation options
      */
     public callWithWeirdParameterNames(
         queryParams: {
@@ -3055,8 +3250,14 @@ export abstract class ParametersService {
         parameterPath1?: string,
         parameterPath2?: string,
         parameterPath3?: string,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
@@ -3067,11 +3268,15 @@ export abstract class ParametersService {
             headers: {
                 'parameter.header': parameterHeader,
             },
-            query: queryParams,
+            query: {
+                'default': data._default,
+                'parameter-query': data.parameterQuery,
+            },
             formData: {
                 'parameter_form': parameterForm,
             },
-            body: parameterBody,
+            body: {
+            },
         });
     }
 
@@ -3097,20 +3302,36 @@ export abstract class ResponseService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns ModelWithString Message for default response
      */
-    public callWithResponse(): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<ModelWithString, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/response',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns ModelWithString Message for default response
      */
-    public callWithDuplicateResponses(): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithDuplicateResponses(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<ModelWithString, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/response',
             errors: {
@@ -3122,17 +3343,25 @@ export abstract class ResponseService {
     }
 
     /**
+     * @param options Additional operation options
      * @returns any Message for 200 response
      * @returns ModelWithString Message for default response
      * @returns ModelThatExtends Message for 201 response
      * @returns ModelThatExtendsExtends Message for 202 response
      */
-    public callWithResponses(): Promise<Result<{
+    public callWithResponses(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<{
         readonly '@namespaceString'?: string;
         readonly '@namespaceInteger'?: number;
         readonly value?: Array<ModelWithString>;
     } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
             errors: {
@@ -3161,63 +3390,119 @@ export abstract class SimpleService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public getCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public getCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public putCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public putCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public postCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public postCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public deleteCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public deleteCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public optionsCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public optionsCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public headCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public headCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public patchCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public patchCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
         });
@@ -3243,6 +3528,7 @@ export abstract class TypesService {
     /**
      * @param queryParams
      * @param id This is a number parameter
+     * @param options Additional operation options
      * @returns number Response is a simple number
      * @returns string Response is a simple string
      * @returns boolean Response is a simple boolean
@@ -3280,14 +3566,28 @@ export abstract class TypesService {
             parameterEnum: 'Success' | 'Warning' | 'Error';
         },
         id?: number,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<number | string | boolean | any, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
                 'id': id,
             },
-            query: queryParams,
+            query: {
+                'parameterNumber': data.parameterNumber,
+                'parameterString': data.parameterString,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterObject': data.parameterObject,
+                'parameterArray': data.parameterArray,
+                'parameterDictionary': data.parameterDictionary,
+                'parameterEnum': data.parameterEnum,
+            },
         });
     }
 
@@ -6431,10 +6731,11 @@ export abstract class CollectionFormatService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public collectionFormat(
-        queryParams: {
+        data: {
             /**
              * This is an array parameter that is sent as csv format (comma-separated values)
              */
@@ -6455,12 +6756,24 @@ export abstract class CollectionFormatService {
              * This is an array parameter that is sent as multi format (multiple parameter instances)
              */
             parameterArrayMulti: Array<string> | null;
-        } | null,
+        },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
-            query: queryParams,
+            query: {
+                'parameterArrayCSV': data.parameterArrayCsv,
+                'parameterArraySSV': data.parameterArraySsv,
+                'parameterArrayTSV': data.parameterArrayTsv,
+                'parameterArrayPipes': data.parameterArrayPipes,
+                'parameterArrayMulti': data.parameterArrayMulti,
+            },
         });
     }
 
@@ -6488,11 +6801,12 @@ export abstract class ComplexService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      * @returns ModelWithString Successful response
      */
     public complexTypes(
-        queryParams: {
+        data: {
             /**
              * Parameter containing object
              */
@@ -6508,11 +6822,20 @@ export abstract class ComplexService {
              */
             parameterReference: ModelWithString;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<Array<ModelWithString>, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
-            query: queryParams,
+            query: {
+                'parameterObject': data.parameterObject,
+                'parameterReference': data.parameterReference,
+            },
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -6522,32 +6845,48 @@ export abstract class ComplexService {
 
     /**
      * @param id
-     * @param requestBody
+     * @param data
+     * @param options Additional operation options
      * @returns ModelWithString Success
      */
     public complexParams(
         id: integer,
-        requestBody?: {
+        data?: {
             readonly key: string | null;
             name: string | null;
-            enabled?: boolean;
             readonly type: 'Monkey' | 'Horse' | 'Bird';
+            parameters: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
+            enabled?: boolean;
             listOfModels?: Array<ModelWithString> | null;
             listOfStrings?: Array<string> | null;
-            parameters: (ModelWithString | ModelWithEnum | ModelWithArray | ModelWithDictionary);
             readonly user?: {
                 readonly id?: integer;
                 readonly name?: string | null;
             };
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/complex/{id}',
             path: {
                 'id': id,
             },
-            body: requestBody,
+            body: {
+                'key': data.key,
+                'name': data.name,
+                'enabled': data.enabled,
+                'type': data.type,
+                'listOfModels': data.listOfModels,
+                'listOfStrings': data.listOfStrings,
+                'parameters': data.parameters,
+                'user': data.user,
+            },
             mediaType: 'application/json-patch+json',
         });
     }
@@ -6570,9 +6909,17 @@ export abstract class DefaultService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public serviceWithEmptyTag(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public serviceWithEmptyTag(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
         });
@@ -6598,10 +6945,11 @@ export abstract class DefaultsService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public callWithDefaultParameters(
-        queryParams?: {
+        data?: {
             /**
              * This is a simple string with default value
              */
@@ -6623,19 +6971,32 @@ export abstract class DefaultsService {
              */
             parameterModel: ModelWithString | null;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterString': data.parameterString,
+                'parameterNumber': data.parameterNumber,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterEnum': data.parameterEnum,
+                'parameterModel': data.parameterModel,
+            },
         });
     }
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public callWithDefaultOptionalParameters(
-        queryParams?: {
+        data?: {
             /**
              * This is a simple string that is optional with default value
              */
@@ -6657,19 +7018,36 @@ export abstract class DefaultsService {
              */
             parameterModel: ModelWithString;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterString': data.parameterString,
+                'parameterNumber': data.parameterNumber,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterEnum': data.parameterEnum,
+                'parameterModel': data.parameterModel,
+            },
         });
     }
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public callToTestOrderOfParams(
-        queryParams: {
+        data: {
+            /**
+             * This is a string with no default
+             */
+            parameterStringWithNoDefault: string;
             /**
              * This is a optional string with default
              */
@@ -6691,10 +7069,6 @@ export abstract class DefaultsService {
              */
             parameterStringWithEmptyDefault: string;
             /**
-             * This is a string with no default
-             */
-            parameterStringWithNoDefault: string;
-            /**
              * This is a string that can be null with no default
              */
             parameterStringNullableWithNoDefault?: string | null;
@@ -6703,11 +7077,26 @@ export abstract class DefaultsService {
              */
             parameterStringNullableWithDefault: string | null;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
-            query: queryParams,
+            query: {
+                'parameterOptionalStringWithDefault': data.parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': data.parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': data.parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': data.parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': data.parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': data.parameterStringWithNoDefault,
+                'parameterStringNullableWithNoDefault': data.parameterStringNullableWithNoDefault,
+                'parameterStringNullableWithDefault': data.parameterStringNullableWithDefault,
+            },
         });
     }
 
@@ -6729,10 +7118,11 @@ export abstract class DescriptionsService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public callWithDescriptions(
-        queryParams?: {
+        data?: {
             /**
              * Testing multiline comments in string: First line
              * Second line
@@ -6761,11 +7151,24 @@ export abstract class DescriptionsService {
              */
             parameterWithReservedCharacters?: any;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
-            query: queryParams,
+            query: {
+                'parameterWithBreaks': data.parameterWithBreaks,
+                'parameterWithBackticks': data.parameterWithBackticks,
+                'parameterWithSlashes': data.parameterWithSlashes,
+                'parameterWithExpressionPlaceholders': data.parameterWithExpressionPlaceholders,
+                'parameterWithQuotes': data.parameterWithQuotes,
+                'parameterWithReservedCharacters': data.parameterWithReservedCharacters,
+            },
         });
     }
 
@@ -6787,36 +7190,68 @@ export abstract class DuplicateService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName1(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName1(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName2(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName2(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public duplicateName3(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public duplicateName3(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
         });
@@ -6840,21 +7275,30 @@ export abstract class ErrorService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      * @returns any Custom message: Successful response
      */
     public testErrorCode(
-        queryParams: {
+        data: {
             /**
              * Status code to return
              */
             status: number;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<any, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/error',
-            query: queryParams,
+            query: {
+                'status': data.status,
+            },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
                 501: \`Custom message: Not Implemented\`,
@@ -6884,22 +7328,29 @@ export abstract class FormDataService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
-     * @param formData A reusable request body
+     * @param data
+     * @param options Additional operation options
      */
     public postApiFormData(
-        queryParams?: {
+        data?: {
             /**
              * This is a reusable parameter
              */
             parameter?: string;
         },
-        formData?: ModelWithString,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/formData/',
-            query: queryParams,
+            query: {
+                'parameter': data.parameter,
+            },
             formData: formData,
             mediaType: 'multipart/form-data',
         });
@@ -6923,10 +7374,18 @@ export abstract class HeaderService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns string Successful response
      */
-    public callWithResultFromHeader(): Promise<Result<string, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithResultFromHeader(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<string, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
@@ -6957,15 +7416,22 @@ export abstract class MultipartService {
     protected abstract config: ClientConfig
 
     /**
-     * @param formData
+     * @param data
+     * @param options Additional operation options
      */
     public multipartRequest(
-        formData?: {
+        data?: {
             content?: Blob;
             data?: ModelWithString | null;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/multipart',
             formData: formData,
@@ -6974,16 +7440,24 @@ export abstract class MultipartService {
     }
 
     /**
+     * @param options Additional operation options
      * @returns any OK
      */
-    public multipartResponse(): Promise<Result<{
+    public multipartResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<{
         file?: Blob;
         metadata?: {
             foo?: string;
             bar?: string;
         };
     }, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multipart',
         });
@@ -7007,20 +7481,36 @@ export abstract class MultipleTags1Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyA(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyA(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7044,20 +7534,36 @@ export abstract class MultipleTags2Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyA(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyA(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7081,10 +7587,18 @@ export abstract class MultipleTags3Service {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public dummyB(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public dummyB(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7108,10 +7622,18 @@ export abstract class NoContentService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns void
      */
-    public callWithNoContentResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithNoContentResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
         });
@@ -7138,27 +7660,32 @@ export abstract class ParametersService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
      * @param parameterHeader This is the parameter that goes into the header
      * @param parameterForm This is the parameter that goes into the form data
      * @param parameterCookie This is the parameter that goes into the cookie
      * @param parameterPath This is the parameter that goes into the path
-     * @param requestBody This is the parameter that goes into the body
+     * @param data
+     * @param options Additional operation options
      */
     public callWithParameters(
-        queryParams: {
-            /**
-             * This is the parameter that goes into the query params
-             */
-            parameterQuery: string | null;
-        } | null,
         parameterHeader: string | null,
         parameterForm: string | null,
         parameterCookie: string | null,
         parameterPath: string | null,
-        requestBody: ModelWithString | null,
+        data: {
+            /**
+             * This is the parameter that goes into the query params
+             */
+            parameterQuery: string | null;
+        },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
@@ -7170,45 +7697,53 @@ export abstract class ParametersService {
             headers: {
                 'parameterHeader': parameterHeader,
             },
-            query: queryParams,
+            query: {
+                'parameterQuery': data.parameterQuery,
+            },
             formData: {
                 'parameterForm': parameterForm,
             },
-            body: requestBody,
+            body: {
+            },
             mediaType: 'application/json',
         });
     }
 
     /**
-     * @param queryParams
      * @param parameterHeader This is the parameter that goes into the request header
      * @param parameterForm This is the parameter that goes into the request form data
      * @param parameterCookie This is the parameter that goes into the cookie
-     * @param requestBody This is the parameter that goes into the body
+     * @param data
      * @param parameterPath1 This is the parameter that goes into the path
      * @param parameterPath2 This is the parameter that goes into the path
      * @param parameterPath3 This is the parameter that goes into the path
+     * @param options Additional operation options
      */
     public callWithWeirdParameterNames(
-        queryParams: {
-            /**
-             * This is the parameter with a reserved keyword
-             */
-            default?: string;
+        parameterHeader: string | null,
+        parameterForm: string | null,
+        parameterCookie: string | null,
+        data: {
             /**
              * This is the parameter that goes into the request query params
              */
             parameterQuery: string | null;
+            /**
+             * This is the parameter with a reserved keyword
+             */
+            default?: string;
         },
-        parameterHeader: string | null,
-        parameterForm: string | null,
-        parameterCookie: string | null,
-        requestBody: ModelWithString | null,
         parameterPath1?: string,
         parameterPath2?: string,
         parameterPath3?: string,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
@@ -7222,55 +7757,75 @@ export abstract class ParametersService {
             headers: {
                 'parameter.header': parameterHeader,
             },
-            query: queryParams,
+            query: {
+                'default': data._default,
+                'parameter-query': data.parameterQuery,
+            },
             formData: {
                 'parameter_form': parameterForm,
             },
-            body: requestBody,
+            body: {
+            },
             mediaType: 'application/json',
         });
     }
 
     /**
-     * @param requestBody This is a required parameter
-     * @param queryParams
+     * @param data
+     * @param options Additional operation options
      */
     public getCallWithOptionalParam(
-        requestBody: ModelWithString,
-        queryParams?: {
+        data: {
             /**
              * This is an optional parameter
              */
             parameter?: string;
         },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/parameters/',
-            query: queryParams,
-            body: requestBody,
+            query: {
+                'parameter': data.parameter,
+            },
+            body: {
+            },
             mediaType: 'application/json',
         });
     }
 
     /**
-     * @param queryParams
-     * @param requestBody This is an optional parameter
+     * @param data
+     * @param options Additional operation options
      */
     public postCallWithOptionalParam(
-        queryParams: {
+        data: {
             /**
              * This is a required parameter
              */
             parameter: Pageable;
         },
-        requestBody?: ModelWithString,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/',
-            query: queryParams,
-            body: requestBody,
+            query: {
+                'parameter': data.parameter,
+            },
+            body: {
+            },
             mediaType: 'application/json',
         });
     }
@@ -7295,23 +7850,31 @@ export abstract class RequestBodyService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
-     * @param requestBody A reusable request body
+     * @param data
+     * @param options Additional operation options
      */
     public postApiRequestBody(
-        queryParams?: {
+        data?: {
             /**
              * This is a reusable parameter
              */
             parameter?: string;
         },
-        requestBody?: ModelWithString,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/requestBody/',
-            query: queryParams,
-            body: requestBody,
+            query: {
+                'parameter': data.parameter,
+            },
+            body: {
+            },
             mediaType: 'application/json',
         });
     }
@@ -7338,20 +7901,36 @@ export abstract class ResponseService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      * @returns ModelWithString
      */
-    public callWithResponse(): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<ModelWithString, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/response',
         });
     }
 
     /**
+     * @param options Additional operation options
      * @returns ModelWithString Message for default response
      */
-    public callWithDuplicateResponses(): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, {
+    public callWithDuplicateResponses(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<ModelWithString, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/response',
             errors: {
@@ -7363,17 +7942,25 @@ export abstract class ResponseService {
     }
 
     /**
+     * @param options Additional operation options
      * @returns any Message for 200 response
      * @returns ModelWithString Message for default response
      * @returns ModelThatExtends Message for 201 response
      * @returns ModelThatExtendsExtends Message for 202 response
      */
-    public callWithResponses(): Promise<Result<{
+    public callWithResponses(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<{
         readonly '@namespaceString'?: string;
         readonly '@namespaceInteger'?: number;
         readonly value?: Array<ModelWithString>;
     } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
             errors: {
@@ -7402,63 +7989,119 @@ export abstract class SimpleService {
     protected abstract config: ClientConfig
 
     /**
+     * @param options Additional operation options
      */
-    public getCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public getCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public putCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public putCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public postCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public postCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public deleteCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public deleteCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public optionsCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public optionsCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public headCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public headCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
         });
     }
 
     /**
+     * @param options Additional operation options
      */
-    public patchCallWithoutParametersAndResponse(): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, {
+    public patchCallWithoutParametersAndResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
         });
@@ -7484,15 +8127,28 @@ export abstract class TypesService {
     protected abstract config: ClientConfig
 
     /**
-     * @param queryParams
+     * @param data
      * @param id This is a number parameter
+     * @param options Additional operation options
      * @returns number Response is a simple number
      * @returns string Response is a simple string
      * @returns boolean Response is a simple boolean
      * @returns any Response is a simple object
      */
     public types(
-        queryParams: {
+        data: {
+            /**
+             * This is an array parameter
+             */
+            parameterArray: Array<string> | null;
+            /**
+             * This is a dictionary parameter
+             */
+            parameterDictionary: any;
+            /**
+             * This is an enum parameter
+             */
+            parameterEnum: 'Success' | 'Warning' | 'Error' | null;
             /**
              * This is a number parameter
              */
@@ -7509,28 +8165,30 @@ export abstract class TypesService {
              * This is an object parameter
              */
             parameterObject: any;
-            /**
-             * This is an array parameter
-             */
-            parameterArray: Array<string> | null;
-            /**
-             * This is a dictionary parameter
-             */
-            parameterDictionary: any;
-            /**
-             * This is an enum parameter
-             */
-            parameterEnum: 'Success' | 'Warning' | 'Error' | null;
         },
         id?: integer,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<number | string | boolean | any, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
                 'id': id,
             },
-            query: queryParams,
+            query: {
+                'parameterNumber': data.parameterNumber,
+                'parameterString': data.parameterString,
+                'parameterBoolean': data.parameterBoolean,
+                'parameterObject': data.parameterObject,
+                'parameterArray': data.parameterArray,
+                'parameterDictionary': data.parameterDictionary,
+                'parameterEnum': data.parameterEnum,
+            },
         });
     }
 
@@ -7553,12 +8211,19 @@ export abstract class UploadService {
 
     /**
      * @param file Supply a file reference for upload
+     * @param options Additional operation options
      * @returns boolean
      */
     public uploadFile(
         file: Blob,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
     ): Promise<Result<boolean, ApiError>> {
-        return __request(this.client, this.config, {
+        return __request(this.client, this.config, options, {
             method: 'POST',
             url: '/api/v{api-version}/upload',
             formData: {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -6885,7 +6885,6 @@ export abstract class ComplexService {
                 'parameters': data?.parameters,
                 'user': data?.user,
             },
-            body: data?.requestBody,
             mediaType: 'application/json-patch+json',
         });
     }
@@ -7710,7 +7709,6 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
-            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7777,7 +7775,6 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
-            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7813,7 +7810,6 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
-            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7849,7 +7845,6 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
-            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7902,7 +7897,6 @@ export abstract class RequestBodyService {
             body: {
                 'prop': data?.prop,
             },
-            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3218,8 +3218,7 @@ export abstract class ParametersService {
             formData: {
                 'parameterForm': parameterForm,
             },
-            body: {
-            },
+            body: data?.parameterBody,
         });
     }
 
@@ -3275,8 +3274,7 @@ export abstract class ParametersService {
             formData: {
                 'parameter_form': parameterForm,
             },
-            body: {
-            },
+            body: data?.parameterBody,
         });
     }
 
@@ -6887,6 +6885,7 @@ export abstract class ComplexService {
                 'parameters': data?.parameters,
                 'user': data?.user,
             },
+            body: data?.requestBody,
             mediaType: 'application/json-patch+json',
         });
     }
@@ -7353,7 +7352,7 @@ export abstract class FormDataService {
             query: {
                 'parameter': data?.parameter,
             },
-            formData: formData,
+            formData: ModelWithString,
             mediaType: 'multipart/form-data',
         });
     }
@@ -7711,6 +7710,7 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
+            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7777,6 +7777,7 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
+            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7812,6 +7813,7 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
+            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7847,6 +7849,7 @@ export abstract class ParametersService {
             body: {
                 'prop': data?.prop,
             },
+            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }
@@ -7899,6 +7902,7 @@ export abstract class RequestBodyService {
             body: {
                 'prop': data?.prop,
             },
+            body: data?.modelWithString,
             mediaType: 'application/json',
         });
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2456,11 +2456,11 @@ export abstract class CollectionFormatService {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
-                'parameterArrayCSV': data.parameterArrayCsv,
-                'parameterArraySSV': data.parameterArraySsv,
-                'parameterArrayTSV': data.parameterArrayTsv,
-                'parameterArrayPipes': data.parameterArrayPipes,
-                'parameterArrayMulti': data.parameterArrayMulti,
+                'parameterArrayCSV': data?.parameterArrayCsv,
+                'parameterArraySSV': data?.parameterArraySsv,
+                'parameterArrayTSV': data?.parameterArrayTsv,
+                'parameterArrayPipes': data?.parameterArrayPipes,
+                'parameterArrayMulti': data?.parameterArrayMulti,
             },
         });
     }
@@ -2517,8 +2517,8 @@ export abstract class ComplexService {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
-                'parameterObject': data.parameterObject,
-                'parameterReference': data.parameterReference,
+                'parameterObject': data?.parameterObject,
+                'parameterReference': data?.parameterReference,
             },
             errors: {
                 400: \`400 server error\`,
@@ -2618,11 +2618,11 @@ export abstract class DefaultsService {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': data.parameterString,
-                'parameterNumber': data.parameterNumber,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterEnum': data.parameterEnum,
-                'parameterModel': data.parameterModel,
+                'parameterString': data?.parameterString,
+                'parameterNumber': data?.parameterNumber,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterEnum': data?.parameterEnum,
+                'parameterModel': data?.parameterModel,
             },
         });
     }
@@ -2665,11 +2665,11 @@ export abstract class DefaultsService {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': data.parameterString,
-                'parameterNumber': data.parameterNumber,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterEnum': data.parameterEnum,
-                'parameterModel': data.parameterModel,
+                'parameterString': data?.parameterString,
+                'parameterNumber': data?.parameterNumber,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterEnum': data?.parameterEnum,
+                'parameterModel': data?.parameterModel,
             },
         });
     }
@@ -2724,14 +2724,14 @@ export abstract class DefaultsService {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterOptionalStringWithDefault': data.parameterOptionalStringWithDefault,
-                'parameterOptionalStringWithEmptyDefault': data.parameterOptionalStringWithEmptyDefault,
-                'parameterOptionalStringWithNoDefault': data.parameterOptionalStringWithNoDefault,
-                'parameterStringWithDefault': data.parameterStringWithDefault,
-                'parameterStringWithEmptyDefault': data.parameterStringWithEmptyDefault,
-                'parameterStringWithNoDefault': data.parameterStringWithNoDefault,
-                'parameterStringNullableWithNoDefault': data.parameterStringNullableWithNoDefault,
-                'parameterStringNullableWithDefault': data.parameterStringNullableWithDefault,
+                'parameterOptionalStringWithDefault': data?.parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': data?.parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': data?.parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': data?.parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': data?.parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': data?.parameterStringWithNoDefault,
+                'parameterStringNullableWithNoDefault': data?.parameterStringNullableWithNoDefault,
+                'parameterStringNullableWithDefault': data?.parameterStringNullableWithDefault,
             },
         });
     }
@@ -2798,12 +2798,12 @@ export abstract class DescriptionsService {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
-                'parameterWithBreaks': data.parameterWithBreaks,
-                'parameterWithBackticks': data.parameterWithBackticks,
-                'parameterWithSlashes': data.parameterWithSlashes,
-                'parameterWithExpressionPlaceholders': data.parameterWithExpressionPlaceholders,
-                'parameterWithQuotes': data.parameterWithQuotes,
-                'parameterWithReservedCharacters': data.parameterWithReservedCharacters,
+                'parameterWithBreaks': data?.parameterWithBreaks,
+                'parameterWithBackticks': data?.parameterWithBackticks,
+                'parameterWithSlashes': data?.parameterWithSlashes,
+                'parameterWithExpressionPlaceholders': data?.parameterWithExpressionPlaceholders,
+                'parameterWithQuotes': data?.parameterWithQuotes,
+                'parameterWithReservedCharacters': data?.parameterWithReservedCharacters,
             },
         });
     }
@@ -2933,7 +2933,7 @@ export abstract class ErrorService {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
-                'status': data.status,
+                'status': data?.status,
             },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
@@ -3213,7 +3213,7 @@ export abstract class ParametersService {
                 'parameterHeader': parameterHeader,
             },
             query: {
-                'parameterQuery': data.parameterQuery,
+                'parameterQuery': data?.parameterQuery,
             },
             formData: {
                 'parameterForm': parameterForm,
@@ -3269,8 +3269,8 @@ export abstract class ParametersService {
                 'parameter.header': parameterHeader,
             },
             query: {
-                'default': data._default,
-                'parameter-query': data.parameterQuery,
+                'default': data?._default,
+                'parameter-query': data?.parameterQuery,
             },
             formData: {
                 'parameter_form': parameterForm,
@@ -3580,13 +3580,13 @@ export abstract class TypesService {
                 'id': id,
             },
             query: {
-                'parameterNumber': data.parameterNumber,
-                'parameterString': data.parameterString,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterObject': data.parameterObject,
-                'parameterArray': data.parameterArray,
-                'parameterDictionary': data.parameterDictionary,
-                'parameterEnum': data.parameterEnum,
+                'parameterNumber': data?.parameterNumber,
+                'parameterString': data?.parameterString,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterObject': data?.parameterObject,
+                'parameterArray': data?.parameterArray,
+                'parameterDictionary': data?.parameterDictionary,
+                'parameterEnum': data?.parameterEnum,
             },
         });
     }
@@ -6768,11 +6768,11 @@ export abstract class CollectionFormatService {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
-                'parameterArrayCSV': data.parameterArrayCsv,
-                'parameterArraySSV': data.parameterArraySsv,
-                'parameterArrayTSV': data.parameterArrayTsv,
-                'parameterArrayPipes': data.parameterArrayPipes,
-                'parameterArrayMulti': data.parameterArrayMulti,
+                'parameterArrayCSV': data?.parameterArrayCsv,
+                'parameterArraySSV': data?.parameterArraySsv,
+                'parameterArrayTSV': data?.parameterArrayTsv,
+                'parameterArrayPipes': data?.parameterArrayPipes,
+                'parameterArrayMulti': data?.parameterArrayMulti,
             },
         });
     }
@@ -6833,8 +6833,8 @@ export abstract class ComplexService {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
-                'parameterObject': data.parameterObject,
-                'parameterReference': data.parameterReference,
+                'parameterObject': data?.parameterObject,
+                'parameterReference': data?.parameterReference,
             },
             errors: {
                 400: \`400 server error\`,
@@ -6878,14 +6878,14 @@ export abstract class ComplexService {
                 'id': id,
             },
             body: {
-                'key': data.key,
-                'name': data.name,
-                'enabled': data.enabled,
-                'type': data.type,
-                'listOfModels': data.listOfModels,
-                'listOfStrings': data.listOfStrings,
-                'parameters': data.parameters,
-                'user': data.user,
+                'key': data?.key,
+                'name': data?.name,
+                'enabled': data?.enabled,
+                'type': data?.type,
+                'listOfModels': data?.listOfModels,
+                'listOfStrings': data?.listOfStrings,
+                'parameters': data?.parameters,
+                'user': data?.user,
             },
             mediaType: 'application/json-patch+json',
         });
@@ -6982,11 +6982,11 @@ export abstract class DefaultsService {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': data.parameterString,
-                'parameterNumber': data.parameterNumber,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterEnum': data.parameterEnum,
-                'parameterModel': data.parameterModel,
+                'parameterString': data?.parameterString,
+                'parameterNumber': data?.parameterNumber,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterEnum': data?.parameterEnum,
+                'parameterModel': data?.parameterModel,
             },
         });
     }
@@ -7029,11 +7029,11 @@ export abstract class DefaultsService {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterString': data.parameterString,
-                'parameterNumber': data.parameterNumber,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterEnum': data.parameterEnum,
-                'parameterModel': data.parameterModel,
+                'parameterString': data?.parameterString,
+                'parameterNumber': data?.parameterNumber,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterEnum': data?.parameterEnum,
+                'parameterModel': data?.parameterModel,
             },
         });
     }
@@ -7088,14 +7088,14 @@ export abstract class DefaultsService {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
-                'parameterOptionalStringWithDefault': data.parameterOptionalStringWithDefault,
-                'parameterOptionalStringWithEmptyDefault': data.parameterOptionalStringWithEmptyDefault,
-                'parameterOptionalStringWithNoDefault': data.parameterOptionalStringWithNoDefault,
-                'parameterStringWithDefault': data.parameterStringWithDefault,
-                'parameterStringWithEmptyDefault': data.parameterStringWithEmptyDefault,
-                'parameterStringWithNoDefault': data.parameterStringWithNoDefault,
-                'parameterStringNullableWithNoDefault': data.parameterStringNullableWithNoDefault,
-                'parameterStringNullableWithDefault': data.parameterStringNullableWithDefault,
+                'parameterOptionalStringWithDefault': data?.parameterOptionalStringWithDefault,
+                'parameterOptionalStringWithEmptyDefault': data?.parameterOptionalStringWithEmptyDefault,
+                'parameterOptionalStringWithNoDefault': data?.parameterOptionalStringWithNoDefault,
+                'parameterStringWithDefault': data?.parameterStringWithDefault,
+                'parameterStringWithEmptyDefault': data?.parameterStringWithEmptyDefault,
+                'parameterStringWithNoDefault': data?.parameterStringWithNoDefault,
+                'parameterStringNullableWithNoDefault': data?.parameterStringNullableWithNoDefault,
+                'parameterStringNullableWithDefault': data?.parameterStringNullableWithDefault,
             },
         });
     }
@@ -7162,12 +7162,12 @@ export abstract class DescriptionsService {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
-                'parameterWithBreaks': data.parameterWithBreaks,
-                'parameterWithBackticks': data.parameterWithBackticks,
-                'parameterWithSlashes': data.parameterWithSlashes,
-                'parameterWithExpressionPlaceholders': data.parameterWithExpressionPlaceholders,
-                'parameterWithQuotes': data.parameterWithQuotes,
-                'parameterWithReservedCharacters': data.parameterWithReservedCharacters,
+                'parameterWithBreaks': data?.parameterWithBreaks,
+                'parameterWithBackticks': data?.parameterWithBackticks,
+                'parameterWithSlashes': data?.parameterWithSlashes,
+                'parameterWithExpressionPlaceholders': data?.parameterWithExpressionPlaceholders,
+                'parameterWithQuotes': data?.parameterWithQuotes,
+                'parameterWithReservedCharacters': data?.parameterWithReservedCharacters,
             },
         });
     }
@@ -7297,7 +7297,7 @@ export abstract class ErrorService {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
-                'status': data.status,
+                'status': data?.status,
             },
             errors: {
                 500: \`Custom message: Internal Server Error\`,
@@ -7349,7 +7349,7 @@ export abstract class FormDataService {
             method: 'POST',
             url: '/api/v{api-version}/formData/',
             query: {
-                'parameter': data.parameter,
+                'parameter': data?.parameter,
             },
             formData: formData,
             mediaType: 'multipart/form-data',
@@ -7698,7 +7698,7 @@ export abstract class ParametersService {
                 'parameterHeader': parameterHeader,
             },
             query: {
-                'parameterQuery': data.parameterQuery,
+                'parameterQuery': data?.parameterQuery,
             },
             formData: {
                 'parameterForm': parameterForm,
@@ -7758,8 +7758,8 @@ export abstract class ParametersService {
                 'parameter.header': parameterHeader,
             },
             query: {
-                'default': data._default,
-                'parameter-query': data.parameterQuery,
+                'default': data?._default,
+                'parameter-query': data?.parameterQuery,
             },
             formData: {
                 'parameter_form': parameterForm,
@@ -7792,7 +7792,7 @@ export abstract class ParametersService {
             method: 'GET',
             url: '/api/v{api-version}/parameters/',
             query: {
-                'parameter': data.parameter,
+                'parameter': data?.parameter,
             },
             body: {
             },
@@ -7822,7 +7822,7 @@ export abstract class ParametersService {
             method: 'POST',
             url: '/api/v{api-version}/parameters/',
             query: {
-                'parameter': data.parameter,
+                'parameter': data?.parameter,
             },
             body: {
             },
@@ -7871,7 +7871,7 @@ export abstract class RequestBodyService {
             method: 'POST',
             url: '/api/v{api-version}/requestBody/',
             query: {
-                'parameter': data.parameter,
+                'parameter': data?.parameter,
             },
             body: {
             },
@@ -8181,13 +8181,13 @@ export abstract class TypesService {
                 'id': id,
             },
             query: {
-                'parameterNumber': data.parameterNumber,
-                'parameterString': data.parameterString,
-                'parameterBoolean': data.parameterBoolean,
-                'parameterObject': data.parameterObject,
-                'parameterArray': data.parameterArray,
-                'parameterDictionary': data.parameterDictionary,
-                'parameterEnum': data.parameterEnum,
+                'parameterNumber': data?.parameterNumber,
+                'parameterString': data?.parameterString,
+                'parameterBoolean': data?.parameterBoolean,
+                'parameterObject': data?.parameterObject,
+                'parameterArray': data?.parameterArray,
+                'parameterDictionary': data?.parameterDictionary,
+                'parameterEnum': data?.parameterEnum,
             },
         });
     }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2452,7 +2452,7 @@ export abstract class CollectionFormatService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
@@ -2513,7 +2513,7 @@ export abstract class ComplexService {
             accountId?: string;
         },
     ): Promise<Result<Array<ModelWithString>, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
@@ -2555,7 +2555,7 @@ export abstract class DefaultService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
         });
@@ -2614,7 +2614,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -2661,7 +2661,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -2720,7 +2720,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -2794,7 +2794,7 @@ export abstract class DescriptionsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
@@ -2836,7 +2836,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
         });
@@ -2853,7 +2853,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
         });
@@ -2870,7 +2870,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
         });
@@ -2887,7 +2887,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
         });
@@ -2929,7 +2929,7 @@ export abstract class ErrorService {
             accountId?: string;
         },
     ): Promise<Result<any, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
@@ -2973,7 +2973,7 @@ export abstract class HeaderService {
             accountId?: string;
         },
     ): Promise<Result<string, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
@@ -3013,7 +3013,7 @@ export abstract class MultipleTags1Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
@@ -3031,7 +3031,7 @@ export abstract class MultipleTags1Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -3066,7 +3066,7 @@ export abstract class MultipleTags2Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
@@ -3084,7 +3084,7 @@ export abstract class MultipleTags2Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -3119,7 +3119,7 @@ export abstract class MultipleTags3Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -3154,7 +3154,7 @@ export abstract class NoContentService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
         });
@@ -3203,7 +3203,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
@@ -3257,7 +3257,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
@@ -3313,7 +3313,7 @@ export abstract class ResponseService {
             accountId?: string;
         },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/response',
         });
@@ -3331,7 +3331,7 @@ export abstract class ResponseService {
             accountId?: string;
         },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/response',
             errors: {
@@ -3361,7 +3361,7 @@ export abstract class ResponseService {
         readonly '@namespaceInteger'?: number;
         readonly value?: Array<ModelWithString>;
     } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
             errors: {
@@ -3400,7 +3400,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
         });
@@ -3417,7 +3417,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
         });
@@ -3434,7 +3434,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
         });
@@ -3451,7 +3451,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
         });
@@ -3468,7 +3468,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
         });
@@ -3485,7 +3485,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
         });
@@ -3502,7 +3502,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
         });
@@ -3573,7 +3573,7 @@ export abstract class TypesService {
             accountId?: string;
         },
     ): Promise<Result<number | string | boolean | any, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
@@ -6764,7 +6764,7 @@ export abstract class CollectionFormatService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/collectionFormat',
             query: {
@@ -6829,7 +6829,7 @@ export abstract class ComplexService {
             accountId?: string;
         },
     ): Promise<Result<Array<ModelWithString>, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
             query: {
@@ -6871,7 +6871,7 @@ export abstract class ComplexService {
             accountId?: string;
         },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/complex/{id}',
             path: {
@@ -6919,7 +6919,7 @@ export abstract class DefaultService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
         });
@@ -6978,7 +6978,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -7025,7 +7025,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -7084,7 +7084,7 @@ export abstract class DefaultsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/defaults',
             query: {
@@ -7158,7 +7158,7 @@ export abstract class DescriptionsService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/descriptions/',
             query: {
@@ -7200,7 +7200,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
         });
@@ -7217,7 +7217,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
         });
@@ -7234,7 +7234,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
         });
@@ -7251,7 +7251,7 @@ export abstract class DuplicateService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
         });
@@ -7293,7 +7293,7 @@ export abstract class ErrorService {
             accountId?: string;
         },
     ): Promise<Result<any, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/error',
             query: {
@@ -7345,7 +7345,7 @@ export abstract class FormDataService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/formData/',
             query: {
@@ -7385,7 +7385,7 @@ export abstract class HeaderService {
             accountId?: string;
         },
     ): Promise<Result<string, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
@@ -7431,7 +7431,7 @@ export abstract class MultipartService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/multipart',
             formData: formData,
@@ -7457,7 +7457,7 @@ export abstract class MultipartService {
             bar?: string;
         };
     }, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multipart',
         });
@@ -7492,7 +7492,7 @@ export abstract class MultipleTags1Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
@@ -7510,7 +7510,7 @@ export abstract class MultipleTags1Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7545,7 +7545,7 @@ export abstract class MultipleTags2Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
         });
@@ -7563,7 +7563,7 @@ export abstract class MultipleTags2Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7598,7 +7598,7 @@ export abstract class MultipleTags3Service {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
         });
@@ -7633,7 +7633,7 @@ export abstract class NoContentService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
         });
@@ -7685,7 +7685,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameterPath}',
             path: {
@@ -7743,7 +7743,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/{parameter.path.1}/{parameter-path-2}/{PARAMETER-PATH-3}',
             path: {
@@ -7788,7 +7788,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/parameters/',
             query: {
@@ -7818,7 +7818,7 @@ export abstract class ParametersService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/parameters/',
             query: {
@@ -7867,7 +7867,7 @@ export abstract class RequestBodyService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/requestBody/',
             query: {
@@ -7912,7 +7912,7 @@ export abstract class ResponseService {
             accountId?: string;
         },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/response',
         });
@@ -7930,7 +7930,7 @@ export abstract class ResponseService {
             accountId?: string;
         },
     ): Promise<Result<ModelWithString, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/response',
             errors: {
@@ -7960,7 +7960,7 @@ export abstract class ResponseService {
         readonly '@namespaceInteger'?: number;
         readonly value?: Array<ModelWithString>;
     } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
             errors: {
@@ -7999,7 +7999,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
         });
@@ -8016,7 +8016,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
         });
@@ -8033,7 +8033,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
         });
@@ -8050,7 +8050,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
         });
@@ -8067,7 +8067,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
         });
@@ -8084,7 +8084,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
         });
@@ -8101,7 +8101,7 @@ export abstract class SimpleService {
             accountId?: string;
         },
     ): Promise<Result<void, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
         });
@@ -8174,7 +8174,7 @@ export abstract class TypesService {
             accountId?: string;
         },
     ): Promise<Result<number | string | boolean | any, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/types',
             path: {
@@ -8223,7 +8223,7 @@ export abstract class UploadService {
             accountId?: string;
         },
     ): Promise<Result<boolean, ApiError>> {
-        return __request(this.client, this.config, options, {
+        return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/upload',
             formData: {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3269,7 +3269,7 @@ export abstract class ParametersService {
                 'parameter.header': parameterHeader,
             },
             query: {
-                'default': data?._default,
+                'default': data?.default,
                 'parameter-query': data?.parameterQuery,
             },
             formData: {
@@ -7315,8 +7315,6 @@ exports[`v3 should generate: ./test/generated/v3/services/FormDataService.ts 1`]
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelWithString } from '../models/ModelWithString.js';
-
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
 import { ApiError } from '../core/ApiError.js'
@@ -7337,6 +7335,10 @@ export abstract class FormDataService {
              * This is a reusable parameter
              */
             parameter?: string;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         options?: {
             /**
@@ -7646,7 +7648,6 @@ exports[`v3 should generate: ./test/generated/v3/services/ParametersService.ts 1
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelWithString } from '../models/ModelWithString.js';
 import type { Pageable } from '../models/Pageable.js';
 
 import { ClientConfig } from '../core/ClientConfig.js'
@@ -7677,6 +7678,10 @@ export abstract class ParametersService {
              * This is the parameter that goes into the query params
              */
             parameterQuery: string | null;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         options?: {
             /**
@@ -7704,6 +7709,7 @@ export abstract class ParametersService {
                 'parameterForm': parameterForm,
             },
             body: {
+                'prop': data?.prop,
             },
             mediaType: 'application/json',
         });
@@ -7732,6 +7738,10 @@ export abstract class ParametersService {
              * This is the parameter with a reserved keyword
              */
             default?: string;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         parameterPath1?: string,
         parameterPath2?: string,
@@ -7758,13 +7768,14 @@ export abstract class ParametersService {
                 'parameter.header': parameterHeader,
             },
             query: {
-                'default': data?._default,
+                'default': data?.default,
                 'parameter-query': data?.parameterQuery,
             },
             formData: {
                 'parameter_form': parameterForm,
             },
             body: {
+                'prop': data?.prop,
             },
             mediaType: 'application/json',
         });
@@ -7780,6 +7791,10 @@ export abstract class ParametersService {
              * This is an optional parameter
              */
             parameter?: string;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         options?: {
             /**
@@ -7795,6 +7810,7 @@ export abstract class ParametersService {
                 'parameter': data?.parameter,
             },
             body: {
+                'prop': data?.prop,
             },
             mediaType: 'application/json',
         });
@@ -7810,6 +7826,10 @@ export abstract class ParametersService {
              * This is a required parameter
              */
             parameter: Pageable;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         options?: {
             /**
@@ -7825,6 +7845,7 @@ export abstract class ParametersService {
                 'parameter': data?.parameter,
             },
             body: {
+                'prop': data?.prop,
             },
             mediaType: 'application/json',
         });
@@ -7837,8 +7858,6 @@ exports[`v3 should generate: ./test/generated/v3/services/RequestBodyService.ts 
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelWithString } from '../models/ModelWithString.js';
-
 import { ClientConfig } from '../core/ClientConfig.js'
 import { request as __request } from '../core/request.js'
 import { ApiError } from '../core/ApiError.js'
@@ -7859,6 +7878,10 @@ export abstract class RequestBodyService {
              * This is a reusable parameter
              */
             parameter?: string;
+            /**
+             * This is a simple string property
+             */
+            prop?: string;
         },
         options?: {
             /**
@@ -7874,6 +7897,7 @@ export abstract class RequestBodyService {
                 'parameter': data?.parameter,
             },
             body: {
+                'prop': data?.prop,
             },
             mediaType: 'application/json',
         });

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -6731,7 +6731,7 @@ export abstract class CollectionFormatService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public collectionFormat(
@@ -6801,7 +6801,7 @@ export abstract class ComplexService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      * @returns ModelWithString Successful response
      */
@@ -6845,7 +6845,7 @@ export abstract class ComplexService {
 
     /**
      * @param id
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      * @returns ModelWithString Success
      */
@@ -6945,7 +6945,7 @@ export abstract class DefaultsService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public callWithDefaultParameters(
@@ -6992,7 +6992,7 @@ export abstract class DefaultsService {
     }
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public callWithDefaultOptionalParameters(
@@ -7039,7 +7039,7 @@ export abstract class DefaultsService {
     }
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public callToTestOrderOfParams(
@@ -7118,7 +7118,7 @@ export abstract class DescriptionsService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public callWithDescriptions(
@@ -7275,7 +7275,7 @@ export abstract class ErrorService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      * @returns any Custom message: Successful response
      */
@@ -7326,7 +7326,7 @@ export abstract class FormDataService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public postApiFormData(
@@ -7418,7 +7418,7 @@ export abstract class MultipartService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public multipartRequest(
@@ -7665,7 +7665,7 @@ export abstract class ParametersService {
      * @param parameterForm This is the parameter that goes into the form data
      * @param parameterCookie This is the parameter that goes into the cookie
      * @param parameterPath This is the parameter that goes into the path
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public callWithParameters(
@@ -7719,7 +7719,7 @@ export abstract class ParametersService {
      * @param parameterHeader This is the parameter that goes into the request header
      * @param parameterForm This is the parameter that goes into the request form data
      * @param parameterCookie This is the parameter that goes into the cookie
-     * @param data
+     * @param data Request data
      * @param parameterPath1 This is the parameter that goes into the path
      * @param parameterPath2 This is the parameter that goes into the path
      * @param parameterPath3 This is the parameter that goes into the path
@@ -7782,7 +7782,7 @@ export abstract class ParametersService {
     }
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public getCallWithOptionalParam(
@@ -7817,7 +7817,7 @@ export abstract class ParametersService {
     }
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public postCallWithOptionalParam(
@@ -7869,7 +7869,7 @@ export abstract class RequestBodyService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param options Additional operation options
      */
     public postApiRequestBody(
@@ -8151,7 +8151,7 @@ export abstract class TypesService {
     protected abstract config: ClientConfig
 
     /**
-     * @param data
+     * @param data Request data
      * @param id This is a number parameter
      * @param options Additional operation options
      * @returns number Response is a simple number


### PR DESCRIPTION
After some debate, we have decide to rework how we present the interface
for service methods. Two main changes are present here:
- Add option to override the account to be used on the endpoint for a
  single operation. This is made with a `options` object that is
optional and currently contains an `accountId` field. If we have more
to add in the future, the object structure allows us to easily do it.
- Move both queryParams and bodyParams to the same object. This makes it
  a lot easier for our clients to use and doesn't leak details about the
underlying API structure. This does require the parameters to not share
any of the property names, but this is already the case and we prefer
the tradeoff.

To note that the new `data` object that holds query and body parameters
is not nullable and it is optional if all parameters contained in it are
optional. The parameters inside `data` have also been sorted by required
status, mimicking the behaviour that existed for when they were outside.

An example of a possible interface with parameters in all places
(descriptions and comments are ommited):
```typescript
public methodX(
    pathParam1: string,
    pathParam2: string,
    data: {
        requestBodyParam1: typeX,
        queryParam2: number,
        requestBodyParam2?: typeZ,
        queryParam1?: string,
    },
    options?: { accountId: string },
)
```

Note: Some of the parser changes aren't reflected for a v2 OpenAPI
schema. This is because the v2 parser changes are a lot harder to do
and since we don't need it (our schema is >v3) we can simply ignore it.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>