### PR TITLE
Remove now obsolete method

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -45,30 +45,6 @@ export class LuneClient {
     public setAccount(accountId: string) {
         this.config.ACCOUNT = accountId
     }
-
-    /**
-     * Perform an action with the current account being set to a desired one.
-     *
-     * The account will only be overridden for the duration of the action and will be restored
-     * to the previous value at the end (when the result of withAccount() is awaited). The
-     * account is also restored in case of an exception.
-     *
-     * This method modifies the internal state of LuneClient. Calling withAccount() or
-     * setAccount() concurrently from multiple contexts at the same time is not supported and
-     * will result in undefined behavior.
-     *
-     * The action's return value is returned by this function as-is.
-     */
-    public async withAccount<T>(accountId: string, action: () => Promise<T>): Promise<T> {
-        const previousAccountId = this.config.ACCOUNT
-        try {
-            this.config.ACCOUNT = accountId
-            return await action()
-        }
-        finally {
-            this.config.ACCOUNT = previousAccountId
-        }
-    }
 }
 
 applyMixins(LuneClient, [

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -715,30 +715,6 @@ export class LuneClient {
     public setAccount(accountId: string) {
         this.config.ACCOUNT = accountId
     }
-
-    /**
-     * Perform an action with the current account being set to a desired one.
-     *
-     * The account will only be overridden for the duration of the action and will be restored
-     * to the previous value at the end (when the result of withAccount() is awaited). The
-     * account is also restored in case of an exception.
-     *
-     * This method modifies the internal state of LuneClient. Calling withAccount() or
-     * setAccount() concurrently from multiple contexts at the same time is not supported and
-     * will result in undefined behavior.
-     *
-     * The action's return value is returned by this function as-is.
-     */
-    public async withAccount<T>(accountId: string, action: () => Promise<T>): Promise<T> {
-        const previousAccountId = this.config.ACCOUNT
-        try {
-            this.config.ACCOUNT = accountId
-            return await action()
-        }
-        finally {
-            this.config.ACCOUNT = previousAccountId
-        }
-    }
 }
 
 applyMixins(LuneClient, [
@@ -4346,30 +4322,6 @@ export class LuneClient {
 
     public setAccount(accountId: string) {
         this.config.ACCOUNT = accountId
-    }
-
-    /**
-     * Perform an action with the current account being set to a desired one.
-     *
-     * The account will only be overridden for the duration of the action and will be restored
-     * to the previous value at the end (when the result of withAccount() is awaited). The
-     * account is also restored in case of an exception.
-     *
-     * This method modifies the internal state of LuneClient. Calling withAccount() or
-     * setAccount() concurrently from multiple contexts at the same time is not supported and
-     * will result in undefined behavior.
-     *
-     * The action's return value is returned by this function as-is.
-     */
-    public async withAccount<T>(accountId: string, action: () => Promise<T>): Promise<T> {
-        const previousAccountId = this.config.ACCOUNT
-        try {
-            this.config.ACCOUNT = accountId
-            return await action()
-        }
-        finally {
-            this.config.ACCOUNT = previousAccountId
-        }
     }
 }
 


### PR DESCRIPTION
The withAccount method was introduced to provide a way to perform an
operation having a different account in the `Lune-Account` header. Since
each method now has an `options` object that allows this override in a
thread safe way, this method is now obsolete. Remove it.

For cases where the purpose is to change the header in a more permanent
fashion, the `setAccount` method can be used.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>