### PR TITLE
Bump version patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.0.9",
+            "version": "0.0.10",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
Removed the `withAccount` method and want to ship that 🚀 

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>