### PR TITLE
Correctly populate default property

### DIFF
--- a/src/openApi/v3/parser/getOperationRequestBody.ts
+++ b/src/openApi/v3/parser/getOperationRequestBody.ts
@@ -53,6 +53,7 @@ export const getOperationRequestBody = (openApi: OpenApi, body: OpenApiRequestBo
                 const model = getModel(openApi, reference, true, definitionType.base);
 
                 requestBody.name = model.name;
+                requestBody.default = model.default;
                 requestBody.export = model.export;
                 requestBody.type = model.type;
                 requestBody.base = model.base;
@@ -82,6 +83,7 @@ export const getOperationRequestBody = (openApi: OpenApi, body: OpenApiRequestBo
                 return requestBody;
             } else {
                 const model = getModel(openApi, content.schema);
+                requestBody.default = model.default;
                 requestBody.export = model.export;
                 requestBody.type = model.type;
                 requestBody.base = model.base;


### PR DESCRIPTION
We weren't correctly populating the property for `requestBody`
parameters which made some fields with a default being marked as
required.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>