### PR TITLE
Fix how default values interact with optional

### DIFF
--- a/src/templates/partials/isRequiredStrict.hbs
+++ b/src/templates/partials/isRequiredStrict.hbs
@@ -1,0 +1,1 @@
+{{#unless isRequired}}?{{/unless}}

--- a/src/templates/partials/typeInterface.hbs
+++ b/src/templates/partials/typeInterface.hbs
@@ -7,9 +7,9 @@
  */
 {{/if}}
 {{#if ../parent}}
-{{>isReadOnly}}{{{camelCase name}}}{{>isRequired}}: {{>type parent=../parent}};
+{{>isReadOnly}}{{{camelCase name}}}{{>isRequiredStrict}}: {{>type parent=../parent}};
 {{else}}
-{{>isReadOnly}}{{{camelCase name}}}{{>isRequired}}: {{>type}};
+{{>isReadOnly}}{{{camelCase name}}}{{>isRequiredStrict}}: {{>type}};
 {{/if}}
 {{/each}}
 }{{>isNullable}}

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -66,6 +66,7 @@ import partialHeader from '../templates/partials/header.hbs';
 import partialIsNullable from '../templates/partials/isNullable.hbs';
 import partialIsReadOnly from '../templates/partials/isReadOnly.hbs';
 import partialIsRequired from '../templates/partials/isRequired.hbs';
+import partialIsRequiredStrict from '../templates/partials/isRequiredStrict.hbs';
 import partialParameters from '../templates/partials/parameters.hbs';
 import partialResult from '../templates/partials/result.hbs';
 import partialSchema from '../templates/partials/schema.hbs';
@@ -149,6 +150,7 @@ export const registerHandlebarTemplates = (root: {
     Handlebars.registerPartial('isNullable', Handlebars.template(partialIsNullable));
     Handlebars.registerPartial('isReadOnly', Handlebars.template(partialIsReadOnly));
     Handlebars.registerPartial('isRequired', Handlebars.template(partialIsRequired));
+    Handlebars.registerPartial('isRequiredStrict', Handlebars.template(partialIsRequiredStrict));
     Handlebars.registerPartial('parameters', Handlebars.template(partialParameters));
     Handlebars.registerPartial('result', Handlebars.template(partialResult));
     Handlebars.registerPartial('schema', Handlebars.template(partialSchema));

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2612,23 +2612,23 @@ export abstract class DefaultsService {
             /**
              * This is a simple string that is optional with default value
              */
-            parameterString: string;
+            parameterString?: string;
             /**
              * This is a simple number that is optional with default value
              */
-            parameterNumber: number;
+            parameterNumber?: number;
             /**
              * This is a simple boolean that is optional with default value
              */
-            parameterBoolean: boolean;
+            parameterBoolean?: boolean;
             /**
              * This is a simple enum that is optional with default value
              */
-            parameterEnum: 'Success' | 'Warning' | 'Error';
+            parameterEnum?: 'Success' | 'Warning' | 'Error';
             /**
              * This is a simple model that is optional with default value
              */
-            parameterModel: ModelWithString;
+            parameterModel?: ModelWithString;
         },
         options?: {
             /**
@@ -2659,11 +2659,11 @@ export abstract class DefaultsService {
             /**
              * This is a optional string with default
              */
-            parameterOptionalStringWithDefault: string;
+            parameterOptionalStringWithDefault?: string;
             /**
              * This is a optional string with empty default
              */
-            parameterOptionalStringWithEmptyDefault: string;
+            parameterOptionalStringWithEmptyDefault?: string;
             /**
              * This is a optional string with no default
              */
@@ -2687,7 +2687,7 @@ export abstract class DefaultsService {
             /**
              * This is a string that can be null with default
              */
-            parameterStringNullableWithDefault: string | null;
+            parameterStringNullableWithDefault?: string | null;
         },
         options?: {
             /**
@@ -6903,23 +6903,23 @@ export abstract class DefaultsService {
             /**
              * This is a simple string with default value
              */
-            parameterString: string | null;
+            parameterString?: string | null;
             /**
              * This is a simple number with default value
              */
-            parameterNumber: number | null;
+            parameterNumber?: number | null;
             /**
              * This is a simple boolean with default value
              */
-            parameterBoolean: boolean | null;
+            parameterBoolean?: boolean | null;
             /**
              * This is a simple enum with default value
              */
-            parameterEnum: 'Success' | 'Warning' | 'Error';
+            parameterEnum?: 'Success' | 'Warning' | 'Error';
             /**
              * This is a simple model with default value
              */
-            parameterModel: ModelWithString | null;
+            parameterModel?: ModelWithString | null;
         },
         options?: {
             /**
@@ -6950,23 +6950,23 @@ export abstract class DefaultsService {
             /**
              * This is a simple string that is optional with default value
              */
-            parameterString: string;
+            parameterString?: string;
             /**
              * This is a simple number that is optional with default value
              */
-            parameterNumber: number;
+            parameterNumber?: number;
             /**
              * This is a simple boolean that is optional with default value
              */
-            parameterBoolean: boolean;
+            parameterBoolean?: boolean;
             /**
              * This is a simple enum that is optional with default value
              */
-            parameterEnum: 'Success' | 'Warning' | 'Error';
+            parameterEnum?: 'Success' | 'Warning' | 'Error';
             /**
              * This is a simple model that is optional with default value
              */
-            parameterModel: ModelWithString;
+            parameterModel?: ModelWithString;
         },
         options?: {
             /**
@@ -7001,11 +7001,11 @@ export abstract class DefaultsService {
             /**
              * This is a optional string with default
              */
-            parameterOptionalStringWithDefault: string;
+            parameterOptionalStringWithDefault?: string;
             /**
              * This is a optional string with empty default
              */
-            parameterOptionalStringWithEmptyDefault: string;
+            parameterOptionalStringWithEmptyDefault?: string;
             /**
              * This is a optional string with no default
              */
@@ -7025,7 +7025,7 @@ export abstract class DefaultsService {
             /**
              * This is a string that can be null with default
              */
-            parameterStringNullableWithDefault: string | null;
+            parameterStringNullableWithDefault?: string | null;
         },
         options?: {
             /**


### PR DESCRIPTION
The initial fix to the issue was correclty passing the default value of a
in the object parsing step itself, this was not correctly being
populated due to our custom made code.

However, this still didn't fully work since the normal handling of a
parameter assumes that when a default exists, the `?` modifier is not
needed since a default is to be provided. The result becomes:
`property: type = default`.

This can occur at parameters of the method, but since we use `properties`
as a way to have a single object parameter in the method (`data`), defaults
cannot exist inside it. The property was being set as not optional since
a default existed, but since the default cannot be populated it was
erratically just being marked as required.

To make sure that a default is still populated on parameters of the
method, but it is correctly only checking the `isRequired` flag for
properties inside `data`, create a `isRequiredStrict` and use it for
properties only (not parameters).

This fully fixes the case of `limit` as a query parameter that is not
required but does have a default. It is now an optional key inside
`data`.

Before/After (when default is present), showcasing it with the `limit`
parameter inside the `data` object:
**Before**
```typescript
methodX(data: { limit: string })
```
**After**
```typescript
methodX(data: { limit?: string })
```

A new template had to be created since if it's a direct parameter of the
method, we can populate with the default value and it is must be marked
as non optional. The behaviour with a default is:
```typescript
methodX(param1: typeZ = defaultValue)
```

If there was no need template and we simply reused `isRequired` these
parameters would also be affected and would become a wrong syntax:
```typescript
methodX(param1?: typeZ = defaultValue)
```

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>