### PR TITLE
Don't ignore empty string enum members

### DIFF
--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -7,7 +7,6 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
             .filter((value, index, arr) => {
                 return arr.indexOf(value) === index;
             })
-            .filter(isDefined)
             .map(value => {
                 if (typeof value === 'number') {
                     return {
@@ -22,7 +21,7 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                         .replace(/\W+/g, '_')
                         .replace(/^(\d+)/g, '_$1')
                         .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                        .toUpperCase() || '__EMPTY__',
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1017,7 +1017,8 @@
                             "enum": [
                                 "Success",
                                 "Warning",
-                                "Error"
+                                "Error",
+                                ""
                             ],
                             "nullable": true
                         }


### PR DESCRIPTION
We actually have a use case since [1] to have an empty string be a valid
enum value.

[1] https://github.com/lune-climate/lune-docs/pull/127