### PR TITLE
Allow empty string as enum entry

### DIFF
--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -16,11 +16,13 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
                     };
                 }
                 return {
-                    name: String(value)
-                        .replace(/\W+/g, '_')
-                        .replace(/^(\d+)/g, '_$1')
-                        .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                        .toUpperCase(),
+                    name: value
+                        ? String(value)
+                              .replace(/\W+/g, '_')
+                              .replace(/^(\d+)/g, '_$1')
+                              .replace(/([a-z])([A-Z]+)/g, '$1_$2')
+                              .toUpperCase()
+                        : '__EMPTY__',
                     value: `'${value.replace(/'/g, "\\'")}'`,
                     type: 'string',
                     description: null,

--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -1,5 +1,4 @@
 import type { Enum } from '../../../client/interfaces/Enum';
-import { isDefined } from '../../../utils/isDefined';
 
 export const getEnum = (values?: (string | number)[]): Enum[] => {
     if (Array.isArray(values)) {
@@ -7,7 +6,6 @@ export const getEnum = (values?: (string | number)[]): Enum[] => {
             .filter((value, index, arr) => {
                 return arr.indexOf(value) === index;
             })
-            .filter(isDefined)
             .map(value => {
                 if (typeof value === 'number') {
                     return {

--- a/src/templates/partials/exportInterface.hbs
+++ b/src/templates/partials/exportInterface.hbs
@@ -26,7 +26,11 @@ export namespace {{{name}}} {
 	{{/if}}
 	export enum {{{name}}} {
 		{{#each enum}}
+		{{#equals name ''}}
+		'' = {{{value}}},
+		{{else}}
 		{{{name}}} = {{{value}}},
+		{{/equals}}
 		{{/each}}
 	}
 

--- a/src/templates/partials/exportInterface.hbs
+++ b/src/templates/partials/exportInterface.hbs
@@ -26,11 +26,7 @@ export namespace {{{name}}} {
 	{{/if}}
 	export enum {{{name}}} {
 		{{#each enum}}
-		{{#equals name ''}}
-		'' = {{{value}}},
-		{{else}}
 		{{{name}}} = {{{value}}},
-		{{/equals}}
 		{{/each}}
 	}
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -5167,7 +5167,7 @@ export namespace ModelWithEmptyStringEnum {
     export enum test {
         ENUM1 = 'Enum1',
         ENUM2 = 'Enum2',
-        '' = '',
+        __EMPTY__ = '',
     }
 
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4152,6 +4152,7 @@ export type { ModelWithCircularReference } from './models/ModelWithCircularRefer
 export type { ModelWithDictionary } from './models/ModelWithDictionary';
 export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports';
 export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties';
+export { ModelWithEmptyStringEnum } from './models/ModelWithEmptyStringEnum';
 export { ModelWithEnum } from './models/ModelWithEnum';
 export { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription';
 export type { ModelWithInteger } from './models/ModelWithInteger';
@@ -4216,6 +4217,7 @@ export { $ModelWithCircularReference } from './schemas/$ModelWithCircularReferen
 export { $ModelWithDictionary } from './schemas/$ModelWithDictionary';
 export { $ModelWithDuplicateImports } from './schemas/$ModelWithDuplicateImports';
 export { $ModelWithDuplicateProperties } from './schemas/$ModelWithDuplicateProperties';
+export { $ModelWithEmptyStringEnum } from './schemas/$ModelWithEmptyStringEnum';
 export { $ModelWithEnum } from './schemas/$ModelWithEnum';
 export { $ModelWithEnumFromDescription } from './schemas/$ModelWithEnumFromDescription';
 export { $ModelWithInteger } from './schemas/$ModelWithInteger';
@@ -4417,6 +4419,7 @@ export type { ModelWithCircularReference } from './models/ModelWithCircularRefer
 export type { ModelWithDictionary } from './models/ModelWithDictionary.js';
 export type { ModelWithDuplicateImports } from './models/ModelWithDuplicateImports.js';
 export type { ModelWithDuplicateProperties } from './models/ModelWithDuplicateProperties.js';
+export { ModelWithEmptyStringEnum } from './models/ModelWithEmptyStringEnum.js';
 export { ModelWithEnum } from './models/ModelWithEnum.js';
 export { ModelWithEnumFromDescription } from './models/ModelWithEnumFromDescription.js';
 export type { ModelWithInteger } from './models/ModelWithInteger.js';
@@ -5138,6 +5141,37 @@ import type { ModelWithString } from './ModelWithString';
 export type ModelWithDuplicateProperties = {
     prop?: ModelWithString;
 };
+"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/ModelWithEmptyStringEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one enum containing an empty string
+ */
+export type ModelWithEmptyStringEnum = {
+    /**
+     * This is a simple enum containing an empty string
+     */
+    test?: ModelWithEmptyStringEnum.test;
+};
+
+export namespace ModelWithEmptyStringEnum {
+
+    /**
+     * This is a simple enum containing an empty string
+     */
+    export enum test {
+        ENUM1 = 'Enum1',
+        ENUM2 = 'Enum2',
+        '' = '',
+    }
+
+
+}
 "
 `;
 
@@ -6282,6 +6316,20 @@ export const $ModelWithDuplicateProperties = {
     properties: {
         prop: {
             type: 'ModelWithString',
+        },
+    },
+} as const;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithEmptyStringEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithEmptyStringEnum = {
+    description: \`This is a model with one enum containing an empty string\`,
+    properties: {
+        test: {
+            type: 'Enum',
         },
     },
 } as const;"

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1782,6 +1782,20 @@
                     }
                 }
             },
+            "ModelWithEmptyStringEnum": {
+                "description": "This is a model with one enum containing an empty string",
+                "type": "object",
+                "properties": {
+                    "test": {
+                        "description": "This is a simple enum containing an empty string",
+                        "enum": [
+                            "Enum1",
+                            "Enum2",
+                            ""
+                        ]
+                    }
+                }
+            },
             "ModelWithEnumFromDescription": {
                 "description": "This is a model with one enum",
                 "type": "object",


### PR DESCRIPTION
This is a usecase we have in our OpenAPI schema. To allow it, the enum
is allowed to pass in the parsing stage, and the template deals with this
special case by naming the enum the empty string ('').

A new model was added to the tests that triggers the new code paths to
make sure generation is working.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>