### PR TITLE
Deal with null as an enum value

### DIFF
--- a/src/openApi/v3/parser/getEnum.ts
+++ b/src/openApi/v3/parser/getEnum.ts
@@ -2,32 +2,36 @@ import type { Enum } from '../../../client/interfaces/Enum';
 
 export const getEnum = (values?: (string | number)[]): Enum[] => {
     if (Array.isArray(values)) {
-        return values
-            .filter((value, index, arr) => {
-                return arr.indexOf(value) === index;
-            })
-            .map(value => {
-                if (typeof value === 'number') {
+        return (
+            values
+                // We have a hack due to our middleware where null is an actual enum member. Ignore it
+                .filter(value => value !== null)
+                .filter((value, index, arr) => {
+                    return arr.indexOf(value) === index;
+                })
+                .map(value => {
+                    if (typeof value === 'number') {
+                        return {
+                            name: `'_${value}'`,
+                            value: String(value),
+                            type: 'number',
+                            description: null,
+                        };
+                    }
                     return {
-                        name: `'_${value}'`,
-                        value: String(value),
-                        type: 'number',
+                        name: value
+                            ? String(value)
+                                  .replace(/\W+/g, '_')
+                                  .replace(/^(\d+)/g, '_$1')
+                                  .replace(/([a-z])([A-Z]+)/g, '$1_$2')
+                                  .toUpperCase()
+                            : '__EMPTY__',
+                        value: `'${value.replace(/'/g, "\\'")}'`,
+                        type: 'string',
                         description: null,
                     };
-                }
-                return {
-                    name: value
-                        ? String(value)
-                              .replace(/\W+/g, '_')
-                              .replace(/^(\d+)/g, '_$1')
-                              .replace(/([a-z])([A-Z]+)/g, '$1_$2')
-                              .toUpperCase()
-                        : '__EMPTY__',
-                    value: `'${value.replace(/'/g, "\\'")}'`,
-                    type: 'string',
-                    description: null,
-                };
-            });
+                })
+        );
     }
     return [];
 };

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4159,6 +4159,7 @@ export type { ModelWithInteger } from './models/ModelWithInteger';
 export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums';
 export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties';
 export type { ModelWithNullableString } from './models/ModelWithNullableString';
+export { ModelWithNullAsEnum } from './models/ModelWithNullAsEnum';
 export type { ModelWithOrderedProperties } from './models/ModelWithOrderedProperties';
 export type { ModelWithPattern } from './models/ModelWithPattern';
 export type { ModelWithProperties } from './models/ModelWithProperties';
@@ -4224,6 +4225,7 @@ export { $ModelWithInteger } from './schemas/$ModelWithInteger';
 export { $ModelWithNestedEnums } from './schemas/$ModelWithNestedEnums';
 export { $ModelWithNestedProperties } from './schemas/$ModelWithNestedProperties';
 export { $ModelWithNullableString } from './schemas/$ModelWithNullableString';
+export { $ModelWithNullAsEnum } from './schemas/$ModelWithNullAsEnum';
 export { $ModelWithOrderedProperties } from './schemas/$ModelWithOrderedProperties';
 export { $ModelWithPattern } from './schemas/$ModelWithPattern';
 export { $ModelWithProperties } from './schemas/$ModelWithProperties';
@@ -4426,6 +4428,7 @@ export type { ModelWithInteger } from './models/ModelWithInteger.js';
 export type { ModelWithNestedEnums } from './models/ModelWithNestedEnums.js';
 export type { ModelWithNestedProperties } from './models/ModelWithNestedProperties.js';
 export type { ModelWithNullableString } from './models/ModelWithNullableString.js';
+export { ModelWithNullAsEnum } from './models/ModelWithNullAsEnum.js';
 export type { ModelWithOrderedProperties } from './models/ModelWithOrderedProperties.js';
 export type { ModelWithPattern } from './models/ModelWithPattern.js';
 export type { ModelWithProperties } from './models/ModelWithProperties.js';
@@ -5306,6 +5309,36 @@ export type ModelWithNestedProperties = {
         } | null;
     } | null;
 };
+"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/ModelWithNullAsEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * This is a model with one enum being the null value. We have this as a hack in place for our middleware
+ */
+export type ModelWithNullAsEnum = {
+    /**
+     * This is a simple enum containing a null as value
+     */
+    test?: ModelWithNullAsEnum.test;
+};
+
+export namespace ModelWithNullAsEnum {
+
+    /**
+     * This is a simple enum containing a null as value
+     */
+    export enum test {
+        ENUM1 = 'Enum1',
+        ENUM2 = 'Enum2',
+    }
+
+
+}
 "
 `;
 
@@ -6446,6 +6479,20 @@ export const $ModelWithNestedProperties = {
             isReadOnly: true,
             isRequired: true,
             isNullable: true,
+        },
+    },
+} as const;"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithNullAsEnum.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithNullAsEnum = {
+    description: \`This is a model with one enum being the null value. We have this as a hack in place for our middleware\`,
+    properties: {
+        test: {
+            type: 'Enum',
         },
     },
 } as const;"

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1796,6 +1796,20 @@
                     }
                 }
             },
+            "ModelWithNullAsEnum": {
+                "description": "This is a model with one enum being the null value. We have this as a hack in place for our middleware",
+                "type": "object",
+                "properties": {
+                    "test": {
+                        "description": "This is a simple enum containing a null as value",
+                        "enum": [
+                            "Enum1",
+                            "Enum2",
+                            null
+                        ]
+                    }
+                }
+            },
             "ModelWithEnumFromDescription": {
                 "description": "This is a model with one enum",
                 "type": "object",


### PR DESCRIPTION
We have a hack in place where some of our enums have `null` as an enum
value. This is done to make our response validation middleware work
correctly. We need to deal with this new value accordingly. Since we
don't actually want to show it in the models, ignore any null as an enum
value. A test was added to verify the behaviour.

This fixes the current rebuild of `lune-ts` while regenerating models from
the OpenAPI schema.

Keep in mind only one line was changed in the parsing logic, but it made
indentation change so github seems to have not understood the change
very efficiently :(

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>