### PR TITLE
Fix snake case keys in error responses

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -37,8 +37,15 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use((response) => {
-            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        const camelCaseResponse = (response) => ({
+            ...response,
+            data: camelCaseKeys(response.data, { deep: true }),
+        })
+        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+            // There's a separate, slightly different callback for errors.
+            error.response = camelCaseResponse(error.response)
+            // We need to return a rejected promise for it to work nice with axios.
+            return Promise.reject(error)
         })
     }
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -707,8 +707,15 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use((response) => {
-            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        const camelCaseResponse = (response) => ({
+            ...response,
+            data: camelCaseKeys(response.data, { deep: true }),
+        })
+        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+            // There's a separate, slightly different callback for errors.
+            error.response = camelCaseResponse(error.response)
+            // We need to return a rejected promise for it to work nice with axios.
+            return Promise.reject(error)
         })
     }
 
@@ -4319,8 +4326,15 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        this.client.interceptors.response.use((response) => {
-            return { ...response, data: camelCaseKeys(response.data, { deep: true }) }
+        const camelCaseResponse = (response) => ({
+            ...response,
+            data: camelCaseKeys(response.data, { deep: true }),
+        })
+        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+            // There's a separate, slightly different callback for errors.
+            error.response = camelCaseResponse(error.response)
+            // We need to return a rejected promise for it to work nice with axios.
+            return Promise.reject(error)
         })
     }
 


### PR DESCRIPTION
We forgot that error responses are processed differently from success responses so we had to modify the camel-case interceptor to handle this.

Previously ApiError.errors contained something like

    {"errors":[{"error_code":"token_invalid","message":"Invalid token."}]}

Now it's

    {"errors":[{"errorCode":"token_invalid","message":"Invalid token."}]}

which matches the type definitions.

This change has been introduce originally in lune-ts directly[1] but then it got overwritten in [2] since the client code is actually autogenerated.

[1] https://github.com/lune-climate/lune-ts/pull/118
[2] https://github.com/lune-climate/lune-ts/pull/120