### PR TITLE
Bump the version to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.0.14",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.0.14",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.0.14",
+    "version": "0.1.0",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
We want to release new changes.

Minor version bump because we're technically breaking backwards compatibility (see [1]).

[1] https://github.com/lune-climate/openapi-typescript-codegen/pull/39