### PR TITLE
Add uuid as a valid format

### DIFF
--- a/src/openApi/v3/parser/getMappedType.ts
+++ b/src/openApi/v3/parser/getMappedType.ts
@@ -31,6 +31,7 @@ const FORMAT_MAPPINGS = new Map<string, MappedType>([
     ['float', { type: 'number', isPrimitive: true }],
     ['date', { type: 'string', isPrimitive: true }],
     ['date-time', { type: 'string', isPrimitive: true }],
+    ['uuid', { type: 'string', isPrimitive: true }],
 ]);
 
 /**


### PR DESCRIPTION
It seems we have introduced this format with the temporary_id from payment, but the base generator was not correctly parsing it. This was making it believe that 'string' was not a primitive type and was trying to include a 'string.js' file. This is making 'lune-ts' fail. Simply add it to our existing list of custom formats as a string.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>