### PR TITLE
Fix service template on multipart/form-data

### DIFF
--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -126,7 +126,15 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{/if}}
 			{{#if parametersBody}}
 			{{#equals parametersBody.in 'formData'}}
+			{{#if parametersBody.properties}}
+			formData: {
+				{{#each parametersBody.properties}}
+				'{{{name}}}': data?.{{{camelCase name}}},
+				{{/each}}
+			},
+			{{else}}
 			formData: {{{parametersBody.name}}},
+			{{/if}}
 			{{/equals}}
 			{{#equals parametersBody.in 'body'}}
 			{{#equals parametersBody.export 'one-of'}}

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -7482,7 +7482,9 @@ export abstract class FormDataService {
             query: {
                 'parameter': data?.parameter,
             },
-            formData: ModelWithString,
+            formData: {
+                'prop': data?.prop,
+            },
             mediaType: 'multipart/form-data',
         });
     }
@@ -7565,7 +7567,10 @@ export abstract class MultipartService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/multipart',
-            formData: formData,
+            formData: {
+                'content': data?.content,
+                'data': data?.data,
+            },
             mediaType: 'multipart/form-data',
         });
     }


### PR DESCRIPTION
We have upgraded the template for when the content-type was json, but we now have cases where the content type is multipart/form-data. This is currently making our generation fail.

The changes are due to our custom changes to improve the user interface.

Signed-off-by: Ruben Aguiar <r.aguiar9080@gmail.com>