### PR TITLE
Fix allOf type at root level

### DIFF
--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -109,9 +109,9 @@ export const getOperation = (
             // if the requestBody is an array, there are no properties to showcase. We instead want to
             // use the whole model as the parameter
             dataParameter.properties.push(requestBody);
-        } else if (requestBody.export === 'one-of') {
-            // if the requestBody is a one-of, the properties cannot be used since they have no names.
-            // Instead we want to use the whole model as the parameter.
+        } else if (requestBody.export === 'one-of' || requestBody.export === 'all-of') {
+            // if the requestBody is a one-of/all-of, the properties cannot be used since they have no
+            // names. Instead we want to use the whole model as the parameter.
             dataParameter.properties = [requestBody];
         }
         dataParameter.isRequired = requestBody.isRequired ? true : dataParameter.isRequired;

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -139,6 +139,8 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#equals parametersBody.in 'body'}}
 			{{#equals parametersBody.export 'one-of'}}
 			body: data?.{{{camelCase parametersBody.name}}},
+			{{else equals parametersBody.export 'all-of'}}
+			body: data?.{{{camelCase parametersBody.name}}},
 			{{else}}
 			{{#if parametersBody.properties}}
 			body: {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -4153,6 +4153,7 @@ export type { ModelCircle } from './models/ModelCircle';
 export type { ModelSquare } from './models/ModelSquare';
 export type { ModelThatExtends } from './models/ModelThatExtends';
 export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends';
+export type { ModelWithAllOfRoot } from './models/ModelWithAllOfRoot';
 export type { ModelWithArray } from './models/ModelWithArray';
 export type { ModelWithBoolean } from './models/ModelWithBoolean';
 export type { ModelWithCircularReference } from './models/ModelWithCircularReference';
@@ -4220,6 +4221,7 @@ export { $ModelCircle } from './schemas/$ModelCircle';
 export { $ModelSquare } from './schemas/$ModelSquare';
 export { $ModelThatExtends } from './schemas/$ModelThatExtends';
 export { $ModelThatExtendsExtends } from './schemas/$ModelThatExtendsExtends';
+export { $ModelWithAllOfRoot } from './schemas/$ModelWithAllOfRoot';
 export { $ModelWithArray } from './schemas/$ModelWithArray';
 export { $ModelWithBoolean } from './schemas/$ModelWithBoolean';
 export { $ModelWithCircularReference } from './schemas/$ModelWithCircularReference';
@@ -4431,6 +4433,7 @@ export type { ModelCircle } from './models/ModelCircle.js';
 export type { ModelSquare } from './models/ModelSquare.js';
 export type { ModelThatExtends } from './models/ModelThatExtends.js';
 export type { ModelThatExtendsExtends } from './models/ModelThatExtendsExtends.js';
+export type { ModelWithAllOfRoot } from './models/ModelWithAllOfRoot.js';
 export type { ModelWithArray } from './models/ModelWithArray.js';
 export type { ModelWithBoolean } from './models/ModelWithBoolean.js';
 export type { ModelWithCircularReference } from './models/ModelWithCircularReference.js';
@@ -5064,6 +5067,23 @@ export type ModelThatExtendsExtends = (ModelWithString & ModelThatExtends & {
     propExtendsC?: string;
     propExtendsD?: ModelWithString;
 });
+"
+`;
+
+exports[`v3 should generate: ./test/generated/v3/models/ModelWithAllOfRoot.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModelWithArray } from './ModelWithArray';
+import type { ModelWithDictionary } from './ModelWithDictionary';
+import type { ModelWithEnum } from './ModelWithEnum';
+import type { ModelWithString } from './ModelWithString';
+
+/**
+ * This is a model that represents a 'all of' relationship
+ */
+export type ModelWithAllOfRoot = (ModelWithString & ModelWithEnum & ModelWithArray & ModelWithDictionary);
 "
 `;
 
@@ -6279,6 +6299,25 @@ export const $ModelThatExtendsExtends = {
 } as const;"
 `;
 
+exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithAllOfRoot.ts 1`] = `
+"/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $ModelWithAllOfRoot = {
+    type: 'all-of',
+    description: \`This is a model that represents a 'all of' relationship\`,
+    contains: [{
+        type: 'ModelWithString',
+    }, {
+        type: 'ModelWithEnum',
+    }, {
+        type: 'ModelWithArray',
+    }, {
+        type: 'ModelWithDictionary',
+    }],
+} as const;"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/schemas/$ModelWithArray.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
@@ -7050,6 +7089,32 @@ export abstract class DefaultService {
             method: 'POST',
             url: '/api/v{api-version}/one-of',
             body: data?.modelWithOneOfRoot,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * @param data Request data
+     * @param options Additional operation options
+     */
+    public serviceWithAllOffRoot(
+        data: {
+            /**
+             * Testing all-of request body at the root level
+             */
+            modelWithAllOfRoot: (ModelWithString & ModelWithEnum & ModelWithArray & ModelWithDictionary);
+        },
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<void, ApiError>> {
+        return __request(this.client, this.config, options || {}, {
+            method: 'POST',
+            url: '/api/v{api-version}/all-of',
+            body: data?.modelWithAllOfRoot,
             mediaType: 'application/json',
         });
     }

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -34,6 +34,24 @@
                 }
             }
         },
+        "/api/v{api-version}/all-of": {
+            "tags": ["AllOf"],
+            "post": {
+                "operationId": "ServiceWithAllOffRoot",
+                "requestBody": {
+                    "description": "Testing all-of request body at the root level",
+                    "required": true,
+                    "nullable": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ModelWithAllOfRoot"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v{api-version}/simple": {
             "get": {
                 "tags": [
@@ -1936,6 +1954,24 @@
                 "description": "This is a model that represents a 'one of' relationship",
                 "type": "object",
                 "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ModelWithString"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ModelWithEnum"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ModelWithArray"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ModelWithDictionary"
+                    }
+                ]
+            },
+            "ModelWithAllOfRoot": {
+                "description": "This is a model that represents a 'all of' relationship",
+                "type": "object",
+                "allOf": [
                     {
                         "$ref": "#/components/schemas/ModelWithString"
                     },


### PR DESCRIPTION
We're having issues currently building lune-ts since we've added a allOf at the root level. This is due to the way we parse properties and how we deal with these properties in the service template. We already have code in place that performs the necessary fixes, but it was only being done for `oneOf`. Simply augment it to `allOf` at the root level as well.

New test was added.