### PR TITLE
Handle connection errors correctly in the generated client

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -43,7 +43,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -713,7 +713,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })
@@ -4334,7 +4336,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })


### PR DESCRIPTION
error is of type any[1] which hides that fact that the response property can be undefined, in which case camelCaseResponse fails with something like (a stacktrace from a project using the library):

    TypeError: Cannot read properties of undefined (reading 'data')
        at camelCaseResponse (file:///lune/lune-shipping-csv-tool/node_modules/@lune-climate/lune/esm/client.js:35:42)
        at file:///lune/lune-shipping-csv-tool/node_modules/@lune-climate/lune/esm/client.js:39:30
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async main (file:///lune/lune-shipping-csv-tool/build/index.js:145:38)

[1] I'll improve that in a separate PR