### PR TITLE
Improve the type annotations in the generated client

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -43,7 +43,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })

--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig'
@@ -37,12 +37,21 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response) => ({
+        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
             ...response,
-            data: camelCaseKeys(response.data, { deep: true }),
+            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+            //
+            // Instead of writing a bunch of type-detecting conditional code to satisfy the
+            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+            // value do we actually deal with here but the library will handle it.
+            data: camelCaseKeys(response.data as any, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
             // There's a separate, slightly different callback for errors.
+            if (!isAxiosError(error)) {
+                throw error
+            }
             if (error.response) {
                 error.response = camelCaseResponse(error.response)
             }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -655,7 +655,7 @@ export { TypesService } from './services/TypesService';
 `;
 
 exports[`v2 should generate: ./test/generated/v2/luneClient.ts 1`] = `
-"import axios, { AxiosInstance } from 'axios'
+"import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig'
@@ -707,12 +707,21 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response) => ({
+        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
             ...response,
-            data: camelCaseKeys(response.data, { deep: true }),
+            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+            //
+            // Instead of writing a bunch of type-detecting conditional code to satisfy the
+            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+            // value do we actually deal with here but the library will handle it.
+            data: camelCaseKeys(response.data as any, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
             // There's a separate, slightly different callback for errors.
+            if (!isAxiosError(error)) {
+                throw error
+            }
             if (error.response) {
                 error.response = camelCaseResponse(error.response)
             }
@@ -4274,7 +4283,7 @@ export { UploadService } from './services/UploadService';
 `;
 
 exports[`v3 should generate: ./test/generated/v3/luneClient.ts 1`] = `
-"import axios, { AxiosInstance } from 'axios'
+"import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig'
@@ -4330,12 +4339,21 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response) => ({
+        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
             ...response,
-            data: camelCaseKeys(response.data, { deep: true }),
+            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+            //
+            // Instead of writing a bunch of type-detecting conditional code to satisfy the
+            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+            // value do we actually deal with here but the library will handle it.
+            data: camelCaseKeys(response.data as any, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error) => {
+        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
             // There's a separate, slightly different callback for errors.
+            if (!isAxiosError(error)) {
+                throw error
+            }
             if (error.response) {
                 error.response = camelCaseResponse(error.response)
             }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -713,7 +713,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })
@@ -4334,7 +4336,9 @@ export class LuneClient {
         })
         this.client.interceptors.response.use(camelCaseResponse, (error) => {
             // There's a separate, slightly different callback for errors.
-            error.response = camelCaseResponse(error.response)
+            if (error.response) {
+                error.response = camelCaseResponse(error.response)
+            }
             // We need to return a rejected promise for it to work nice with axios.
             return Promise.reject(error)
         })


### PR DESCRIPTION
error was explicitly of type "any". Similarly the "response" type was implicitly "any".

As a consequence of the former the compiler didn't notice quite a big problem in the code[1] so we've been shipping bad code.

Let's provide type annotations and make them as narrow as possible to reduce the chance of unnoticed issues left in the code.

Since we now know the type of response.data we need to silence the compiler errors on that one particular line – the comment explains why.

[1] https://github.com/lune-climate/openapi-typescript-codegen/pull/51