### PR TITLE
Release version 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
Originally I created [1] for this but I had an out-of-date master branch locally and didn't notice 0.1.4 had been taken already[2].

Contains a bug fix[2] and improved type annotations in the generated code[3].

[1] 9388744c7fab ("Release version 0.1.4 (#53)")
[2] f0961e66776c ("Bump version (patch) (#50)")
[3] https://github.com/lune-climate/openapi-typescript-codegen/pull/51
[4] https://github.com/lune-climate/openapi-typescript-codegen/pull/52