### PR TITLE
Release version 0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
We have a fix for the auto-generated code working in ESM projects[1] and we need to ship a new version so we can use it in our TS client[2].

Part of: https://linear.app/lune/issue/LUN-2681/js-extensions-missing-from-the-ts-client-esm-build

[1] https://github.com/lune-climate/openapi-typescript-codegen/commit/413de29b0bb8743afde32b37ab82d6dcc2cf4850
[2] https://github.com/lune-climate/lune-ts