### PR TITLE
Fix `data` being wrongly considered optional

### DIFF
--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -115,7 +115,7 @@ export const getOperation = (
         const queryParams = parameters.parameters.filter(p => p.in === 'query');
         if (queryParams.length !== 0) {
             dataParameter.properties.push(...queryParams);
-            dataParameter.isRequired = !!queryParams.find(p => p.isRequired);
+            dataParameter.isRequired = !!queryParams.find(p => p.isRequired) ? true : dataParameter.isRequired;
         }
     }
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -10130,7 +10130,7 @@ export abstract class OneOfService {
      * @param options Additional operation options
      */
     public queryParamsWithOneOf(
-        data?: {
+        data: {
             /**
              * Testing allOf request body at the root level
              */
@@ -10311,7 +10311,7 @@ export abstract class ParametersService {
      * @param options Additional operation options
      */
     public getCallWithOptionalParam(
-        data?: {
+        data: {
             /**
              * This is a simple string property
              */


### PR DESCRIPTION
Due to the latest change to fix how query parameters are handled, the `isRequired` flag on the internal model was not being correctly preserved. If the requestBody is mandatory then the whole `data` object is mandatory, same for query parameters. We were wrongly overwriting `isRequired` to whatever the query params stated, but we want to preserve this information since the requestBody has been processed at this point now.