### PR TITLE
Release version 0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
We have a fairly important bugfix[1] to release.

[1] 17cf9f5cb0b6 ("Fix null enum handling inside anyOf/allOf/oneOf (#65)")