### PR TITLE
Update LuneClient's template to populate response with metadata

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -2,6 +2,11 @@ import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
+import {
+    ExtendedAxiosError,
+    ExtendedAxiosResponse,
+    extractRequestFromResponseInterceptor,
+} from './core/SuccessResponse.js'
 {{#each services}}
 import { {{{name}}}Service } from './services/{{{name}}}Service.js';
 {{/each}}
@@ -37,27 +42,34 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
             ...response,
+            _meta: {
+                ...extractRequestFromResponseInterceptor(response),
+                response: response.data,
+            },
             // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
             // handles all kinds of values just fine: arrays, numbers, strings, null etc.
             //
             // Instead of writing a bunch of type-detecting conditional code to satisfy the
             // TS compiler let's just wholesale ignore this type mismatch – we don't know what
             // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data as any, { deep: true }),
+            data: camelCaseKeys(response.data, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
-            // There's a separate, slightly different callback for errors.
-            if (!isAxiosError(error)) {
-                throw error
-            }
-            if (error.response) {
-                error.response = camelCaseResponse(error.response)
-            }
-            // We need to return a rejected promise for it to work nice with axios.
-            return Promise.reject(error)
-        })
+        this.client.interceptors.response.use(
+            camelCaseResponse,
+            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+                // There's a separate, slightly different callback for errors.
+                if (!isAxiosError(error)) {
+                    throw error
+                }
+                if (error.response) {
+                    error.response = camelCaseResponse(error.response)
+                }
+                // We need to return a rejected promise for it to work nice with axios.
+                return Promise.reject(error)
+            },
+        )
     }
 
     public setAccount(accountId: string) {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -715,6 +715,11 @@ exports[`v2 should generate: ./test/generated/v2/luneClient.ts 1`] = `
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
+import {
+    ExtendedAxiosError,
+    ExtendedAxiosResponse,
+    extractRequestFromResponseInterceptor,
+} from './core/SuccessResponse.js'
 import { CollectionFormatService } from './services/CollectionFormatService.js';
 import { ComplexService } from './services/ComplexService.js';
 import { DefaultService } from './services/DefaultService.js';
@@ -763,27 +768,34 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
             ...response,
+            _meta: {
+                ...extractRequestFromResponseInterceptor(response),
+                response: response.data,
+            },
             // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
             // handles all kinds of values just fine: arrays, numbers, strings, null etc.
             //
             // Instead of writing a bunch of type-detecting conditional code to satisfy the
             // TS compiler let's just wholesale ignore this type mismatch – we don't know what
             // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data as any, { deep: true }),
+            data: camelCaseKeys(response.data, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
-            // There's a separate, slightly different callback for errors.
-            if (!isAxiosError(error)) {
-                throw error
-            }
-            if (error.response) {
-                error.response = camelCaseResponse(error.response)
-            }
-            // We need to return a rejected promise for it to work nice with axios.
-            return Promise.reject(error)
-        })
+        this.client.interceptors.response.use(
+            camelCaseResponse,
+            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+                // There's a separate, slightly different callback for errors.
+                if (!isAxiosError(error)) {
+                    throw error
+                }
+                if (error.response) {
+                    error.response = camelCaseResponse(error.response)
+                }
+                // We need to return a rejected promise for it to work nice with axios.
+                return Promise.reject(error)
+            },
+        )
     }
 
     public setAccount(accountId: string) {
@@ -5304,6 +5316,11 @@ exports[`v3 should generate: ./test/generated/v3/luneClient.ts 1`] = `
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
+import {
+    ExtendedAxiosError,
+    ExtendedAxiosResponse,
+    extractRequestFromResponseInterceptor,
+} from './core/SuccessResponse.js'
 import { CollectionFormatService } from './services/CollectionFormatService.js';
 import { ComplexService } from './services/ComplexService.js';
 import { DefaultService } from './services/DefaultService.js';
@@ -5357,27 +5374,34 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse<unknown, unknown>) => ({
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
             ...response,
+            _meta: {
+                ...extractRequestFromResponseInterceptor(response),
+                response: response.data,
+            },
             // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
             // handles all kinds of values just fine: arrays, numbers, strings, null etc.
             //
             // Instead of writing a bunch of type-detecting conditional code to satisfy the
             // TS compiler let's just wholesale ignore this type mismatch – we don't know what
             // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data as any, { deep: true }),
+            data: camelCaseKeys(response.data, { deep: true }),
         })
-        this.client.interceptors.response.use(camelCaseResponse, (error: unknown) => {
-            // There's a separate, slightly different callback for errors.
-            if (!isAxiosError(error)) {
-                throw error
-            }
-            if (error.response) {
-                error.response = camelCaseResponse(error.response)
-            }
-            // We need to return a rejected promise for it to work nice with axios.
-            return Promise.reject(error)
-        })
+        this.client.interceptors.response.use(
+            camelCaseResponse,
+            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+                // There's a separate, slightly different callback for errors.
+                if (!isAxiosError(error)) {
+                    throw error
+                }
+                if (error.response) {
+                    error.response = camelCaseResponse(error.response)
+                }
+                // We need to return a rejected promise for it to work nice with axios.
+                return Promise.reject(error)
+            },
+        )
     }
 
     public setAccount(accountId: string) {


### PR DESCRIPTION
https://github.com/lune-climate/openapi-typescript-codegen/pull/67 introduces SuccessResponse<T>.

This change ensures the LuneClient template populates the data accordingly.