### PR TITLE
Release version 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.1.12",
+            "version": "0.1.13",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "Fork of: https://github.com/ferdikoomen/openapi-typescript-codegen. Library that generates Typescript clients based on the OpenAPI specification.",
     "author": "Lune",
     "homepage": "https://github.com/lune-climate/openapi-typescript-codegen",


### PR DESCRIPTION
* Add new required parameter `api-version`. It is used to populate the config parameter in LuneClient template.