### PR TITLE
Add exception to unsafe declaration

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -32,6 +32,7 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
     })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class LuneClient {
     protected client: AxiosInstance
     protected config: ClientConfig
@@ -95,7 +96,7 @@ applyMixins(LuneClient, [
     {{/if}}
 ])
 
-// eslint-disable-next-line no-redeclare -- mixins require same name
+// eslint-disable-next-line no-redeclare, @typescript-eslint/no-unsafe-declaration-merging -- mixins require same name
 export interface LuneClient extends
     {{#each services}}
     {{{name}}}Service{{#unless @last}},{{/unless}}

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -758,6 +758,7 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
     })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class LuneClient {
     protected client: AxiosInstance
     protected config: ClientConfig
@@ -832,7 +833,7 @@ applyMixins(LuneClient, [
     TypesService,
 ])
 
-// eslint-disable-next-line no-redeclare -- mixins require same name
+// eslint-disable-next-line no-redeclare, @typescript-eslint/no-unsafe-declaration-merging -- mixins require same name
 export interface LuneClient extends
     CollectionFormatService,
         ComplexService,
@@ -5374,6 +5375,7 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
     })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class LuneClient {
     protected client: AxiosInstance
     protected config: ClientConfig
@@ -5453,7 +5455,7 @@ applyMixins(LuneClient, [
     UploadService,
 ])
 
-// eslint-disable-next-line no-redeclare -- mixins require same name
+// eslint-disable-next-line no-redeclare, @typescript-eslint/no-unsafe-declaration-merging -- mixins require same name
 export interface LuneClient extends
     CollectionFormatService,
         ComplexService,


### PR DESCRIPTION
This fixes the following error: https://github.com/lune-climate/lune-ts/actions/runs/10828711568/job/30044690977?pr=670

Adding an exception because, as the comment states, mixins interfaces require the same name as the class.