### PR TITLE
Only apply response interceptor transformations to JSON responses

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -55,23 +55,23 @@ export class LuneClient {
         // Convert to camelCase when receiving JSON responses
         const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
-            if (contentType && contentType.includes('application/json')) {
-                return {
-                    ...response,
-                    _meta: {
-                        ...extractRequestFromResponseInterceptor(response),
-                        response: response.data,
-                    },
-                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-                    //
-                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
-                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-                    // value do we actually deal with here but the library will handle it.
-                    data: camelCaseKeys(response.data, { deep: true }),
-                }
+            if (!contentType || !contentType.includes('application/json')) {
+                return response
             }
-            return response
+            return {
+                ...response,
+                _meta: {
+                    ...extractRequestFromResponseInterceptor(response),
+                    response: response.data,
+                },
+                // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                //
+                // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                // value do we actually deal with here but the library will handle it.
+                data: camelCaseKeys(response.data, { deep: true }),
+            }
         }
         this.client.interceptors.response.use(
             camelCaseResponse,

--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -52,21 +52,27 @@ export class LuneClient {
         }
         this.client = axios.create()
 
-        // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
-            ...response,
-            _meta: {
-                ...extractRequestFromResponseInterceptor(response),
-                response: response.data,
-            },
-            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-            //
-            // Instead of writing a bunch of type-detecting conditional code to satisfy the
-            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-            // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data, { deep: true }),
-        })
+        // Convert to camelCase when receiving JSON responses
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+            const contentType = response.headers['content-type']
+            if (contentType && contentType.includes('application/json')) {
+                return {
+                    ...response,
+                    _meta: {
+                        ...extractRequestFromResponseInterceptor(response),
+                        response: response.data,
+                    },
+                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                    //
+                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                    // value do we actually deal with here but the library will handle it.
+                    data: camelCaseKeys(response.data, { deep: true }),
+                }
+            }
+            return response
+        }
         this.client.interceptors.response.use(
             camelCaseResponse,
             (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -781,20 +781,26 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
-            ...response,
-            _meta: {
-                ...extractRequestFromResponseInterceptor(response),
-                response: response.data,
-            },
-            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-            //
-            // Instead of writing a bunch of type-detecting conditional code to satisfy the
-            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-            // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data, { deep: true }),
-        })
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+            const contentType = response.headers['content-type']
+            if (contentType && contentType.includes('application/json')) {
+                return {
+                    ...response,
+                    _meta: {
+                        ...extractRequestFromResponseInterceptor(response),
+                        response: response.data,
+                    },
+                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                    //
+                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                    // value do we actually deal with here but the library will handle it.
+                    data: camelCaseKeys(response.data, { deep: true }),
+                }
+            }
+            return response
+        }
         this.client.interceptors.response.use(
             camelCaseResponse,
             (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
@@ -5439,20 +5445,26 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving request
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => ({
-            ...response,
-            _meta: {
-                ...extractRequestFromResponseInterceptor(response),
-                response: response.data,
-            },
-            // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-            // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-            //
-            // Instead of writing a bunch of type-detecting conditional code to satisfy the
-            // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-            // value do we actually deal with here but the library will handle it.
-            data: camelCaseKeys(response.data, { deep: true }),
-        })
+        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+            const contentType = response.headers['content-type']
+            if (contentType && contentType.includes('application/json')) {
+                return {
+                    ...response,
+                    _meta: {
+                        ...extractRequestFromResponseInterceptor(response),
+                        response: response.data,
+                    },
+                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                    //
+                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                    // value do we actually deal with here but the library will handle it.
+                    data: camelCaseKeys(response.data, { deep: true }),
+                }
+            }
+            return response
+        }
         this.client.interceptors.response.use(
             camelCaseResponse,
             (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -780,26 +780,26 @@ export class LuneClient {
         }
         this.client = axios.create()
 
-        // Convert to camelCase when receiving request
+        // Convert to camelCase when receiving JSON responses
         const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
-            if (contentType && contentType.includes('application/json')) {
-                return {
-                    ...response,
-                    _meta: {
-                        ...extractRequestFromResponseInterceptor(response),
-                        response: response.data,
-                    },
-                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-                    //
-                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
-                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-                    // value do we actually deal with here but the library will handle it.
-                    data: camelCaseKeys(response.data, { deep: true }),
-                }
+            if (!contentType || !contentType.includes('application/json')) {
+                return response
             }
-            return response
+            return {
+                ...response,
+                _meta: {
+                    ...extractRequestFromResponseInterceptor(response),
+                    response: response.data,
+                },
+                // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                //
+                // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                // value do we actually deal with here but the library will handle it.
+                data: camelCaseKeys(response.data, { deep: true }),
+            }
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
@@ -5444,26 +5444,26 @@ export class LuneClient {
         }
         this.client = axios.create()
 
-        // Convert to camelCase when receiving request
+        // Convert to camelCase when receiving JSON responses
         const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
-            if (contentType && contentType.includes('application/json')) {
-                return {
-                    ...response,
-                    _meta: {
-                        ...extractRequestFromResponseInterceptor(response),
-                        response: response.data,
-                    },
-                    // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
-                    // handles all kinds of values just fine: arrays, numbers, strings, null etc.
-                    //
-                    // Instead of writing a bunch of type-detecting conditional code to satisfy the
-                    // TS compiler let's just wholesale ignore this type mismatch – we don't know what
-                    // value do we actually deal with here but the library will handle it.
-                    data: camelCaseKeys(response.data, { deep: true }),
-                }
+            if (!contentType || !contentType.includes('application/json')) {
+                return response
             }
-            return response
+            return {
+                ...response,
+                _meta: {
+                    ...extractRequestFromResponseInterceptor(response),
+                    response: response.data,
+                },
+                // SAFETY: The camelcase-keys type definitions are overly restrictive. The function
+                // handles all kinds of values just fine: arrays, numbers, strings, null etc.
+                //
+                // Instead of writing a bunch of type-detecting conditional code to satisfy the
+                // TS compiler let's just wholesale ignore this type mismatch – we don't know what
+                // value do we actually deal with here but the library will handle it.
+                data: camelCaseKeys(response.data, { deep: true }),
+            }
         }
         this.client.interceptors.response.use(
             camelCaseResponse,


### PR DESCRIPTION
If the response returns other types of content, for instance 'application/pdf' or 'image/png', applying the transformation is incorrect.