### PR TITLE
Update package-lock.json with the newest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lune-climate/openapi-typescript-codegen",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lune-climate/openapi-typescript-codegen",
-            "version": "0.1.15",
+            "version": "0.1.16",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",


### PR DESCRIPTION
Forgotten here https://github.com/lune-climate/openapi-typescript-codegen/pull/80.