### PR TITLE
Fix interceptor types

### DIFF
--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -7,7 +7,7 @@
 // (You can modify this by hand if its extension is .hbs)
 //
 // =======================================================================
-import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
+import axios, { AxiosError, AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
@@ -53,7 +53,7 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving JSON responses
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+        const camelCaseResponse = (response: AxiosResponse): AxiosResponse | ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
             if (!contentType || !contentType.includes('application/json')) {
                 return response
@@ -75,7 +75,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error

--- a/src/templates/luneClient.hbs
+++ b/src/templates/luneClient.hbs
@@ -75,7 +75,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosError | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -722,7 +722,7 @@ exports[`v2 should generate: ./test/generated/v2/luneClient.ts 1`] = `
 // (You can modify this by hand if its extension is .hbs)
 //
 // =======================================================================
-import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
+import axios, { AxiosError, AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
@@ -781,7 +781,7 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving JSON responses
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+        const camelCaseResponse = (response: AxiosResponse): AxiosResponse | ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
             if (!contentType || !contentType.includes('application/json')) {
                 return response
@@ -803,7 +803,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error
@@ -5381,7 +5381,7 @@ exports[`v3 should generate: ./test/generated/v3/luneClient.ts 1`] = `
 // (You can modify this by hand if its extension is .hbs)
 //
 // =======================================================================
-import axios, { AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
+import axios, { AxiosError, AxiosInstance, AxiosResponse, isAxiosError } from 'axios'
 import camelCaseKeys from 'camelcase-keys'
 
 import { ClientConfig } from './core/ClientConfig.js'
@@ -5445,7 +5445,7 @@ export class LuneClient {
         this.client = axios.create()
 
         // Convert to camelCase when receiving JSON responses
-        const camelCaseResponse = (response: AxiosResponse): ExtendedAxiosResponse => {
+        const camelCaseResponse = (response: AxiosResponse): AxiosResponse | ExtendedAxiosResponse => {
             const contentType = response.headers['content-type']
             if (!contentType || !contentType.includes('application/json')) {
                 return response
@@ -5467,7 +5467,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: ExtendedAxiosError): Promise<ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -803,7 +803,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosError | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error
@@ -5467,7 +5467,7 @@ export class LuneClient {
         }
         this.client.interceptors.response.use(
             camelCaseResponse,
-            (error: AxiosError | ExtendedAxiosError): Promise<AxiosResponse | ExtendedAxiosError> => {
+            (error: AxiosError | ExtendedAxiosError): Promise<AxiosError | ExtendedAxiosError> => {
                 // There's a separate, slightly different callback for errors.
                 if (!isAxiosError(error)) {
                     throw error


### PR DESCRIPTION
In https://github.com/lune-climate/openapi-typescript-codegen/pull/79 I've disabled interceptor transformations for non-JSON responses.

I failed to update types.

I only realised when using the library: https://github.com/lune-climate/lune-ts/actions/runs/12377342754/job/34546625081?pr=770.