### PR TITLE
Support binary responses (v3 only)

### DIFF
--- a/src/client/interfaces/Operation.d.ts
+++ b/src/client/interfaces/Operation.d.ts
@@ -13,4 +13,5 @@ export interface Operation extends OperationParameters {
     errors: OperationError[];
     results: OperationResponse[];
     responseHeader: string | null;
+    responseType: 'arraybuffer' | 'document' | 'json' | 'text' | 'stream' | 'blob' | null;
 }

--- a/src/client/interfaces/OperationResponse.d.ts
+++ b/src/client/interfaces/OperationResponse.d.ts
@@ -3,4 +3,5 @@ import type { Model } from './Model';
 export interface OperationResponse extends Model {
     in: 'response' | 'header';
     code: number;
+    mediaType: string | null;
 }

--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -44,6 +44,7 @@ export const getOperation = (
         errors: [],
         results: [],
         responseHeader: null,
+        responseType: 'json',
     };
 
     // Parse the operation parameters (path, query, body, etc).

--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -44,7 +44,7 @@ export const getOperation = (
         errors: [],
         results: [],
         responseHeader: null,
-        responseType: 'json',
+        responseType: null,
     };
 
     // Parse the operation parameters (path, query, body, etc).

--- a/src/openApi/v2/parser/getOperationResponse.ts
+++ b/src/openApi/v2/parser/getOperationResponse.ts
@@ -30,6 +30,7 @@ export const getOperationResponse = (
         enum: [],
         enums: [],
         properties: [],
+        mediaType: null,
     };
 
     // If this response has a schema, then we need to check two things:

--- a/src/openApi/v2/parser/getOperationResults.ts
+++ b/src/openApi/v2/parser/getOperationResults.ts
@@ -39,6 +39,7 @@ export const getOperationResults = (operationResponses: OperationResponse[]): Op
             enum: [],
             enums: [],
             properties: [],
+            mediaType: null,
         });
     }
 

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -132,32 +132,31 @@ export const getOperation = (
         operation.responseType = getOperationResponseType(operationResults);
 
         // Add 'Accept' header, if not set
-        const explicitAcceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : null;
-        if (!explicitAcceptHeader) {
-            const acceptHeader = getOperationImplicitAcceptHeader(operationResults);
-            if (acceptHeader) {
-                const acceptHeaderOperationParameter: OperationParameter = {
-                    in: 'header',
-                    prop: 'Accept',
-                    export: 'interface',
-                    name: `'${acceptHeader}'`,
-                    type: 'any',
-                    base: 'any',
-                    template: null,
-                    link: null,
-                    description: null,
-                    isDefinition: false,
-                    isReadOnly: false,
-                    isRequired: true,
-                    isNullable: false,
-                    imports: [],
-                    enum: [],
-                    enums: [],
-                    properties: [],
-                    mediaType: null,
-                };
-                operation.parametersHeader.push(acceptHeaderOperationParameter);
-            }
+        const acceptHeader = parameters
+            ? getOperationExplicitAcceptHeader(parameters.parametersHeader)
+            : getOperationImplicitAcceptHeader(operationResults);
+        if (acceptHeader) {
+            const acceptHeaderOperationParameter: OperationParameter = {
+                in: 'header',
+                prop: 'Accept',
+                export: 'interface',
+                name: `'${acceptHeader}'`,
+                type: 'any',
+                base: 'any',
+                template: null,
+                link: null,
+                description: null,
+                isDefinition: false,
+                isReadOnly: false,
+                isRequired: true,
+                isNullable: false,
+                imports: [],
+                enum: [],
+                enums: [],
+                properties: [],
+                mediaType: null,
+            };
+            operation.parametersHeader.push(acceptHeaderOperationParameter);
         }
 
         operationResults.forEach(operationResult => {

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -132,31 +132,32 @@ export const getOperation = (
         operation.responseType = getOperationResponseType(operationResults);
 
         // Add 'Accept' header, if not set
-        const acceptHeader = parameters
-            ? getOperationExplicitAcceptHeader(parameters.parametersHeader)
-            : getOperationImplicitAcceptHeader(operationResults);
-        if (acceptHeader) {
-            const acceptHeaderOperationParameter: OperationParameter = {
-                in: 'header',
-                prop: 'Accept',
-                export: 'interface',
-                name: `'${acceptHeader}'`,
-                type: 'any',
-                base: 'any',
-                template: null,
-                link: null,
-                description: null,
-                isDefinition: false,
-                isReadOnly: false,
-                isRequired: true,
-                isNullable: false,
-                imports: [],
-                enum: [],
-                enums: [],
-                properties: [],
-                mediaType: null,
-            };
-            operation.parametersHeader.push(acceptHeaderOperationParameter);
+        const explicitAcceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : null;
+        if (!explicitAcceptHeader) {
+            const acceptHeader = getOperationImplicitAcceptHeader(operationResults);
+            if (acceptHeader) {
+                const acceptHeaderOperationParameter: OperationParameter = {
+                    in: 'header',
+                    prop: 'Accept',
+                    export: 'interface',
+                    name: `'${acceptHeader}'`,
+                    type: 'any',
+                    base: 'any',
+                    template: null,
+                    link: null,
+                    description: null,
+                    isDefinition: false,
+                    isReadOnly: false,
+                    isRequired: true,
+                    isNullable: false,
+                    imports: [],
+                    enum: [],
+                    enums: [],
+                    properties: [],
+                    mediaType: null,
+                };
+                operation.parametersHeader.push(acceptHeaderOperationParameter);
+            }
         }
 
         operationResults.forEach(operationResult => {

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -132,30 +132,31 @@ export const getOperation = (
         operation.responseType = getOperationResponseType(operationResults);
 
         // Add 'Accept' header, if not set
-        const acceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : getOperationImplicitAcceptHeader(operationResults);
+        const acceptHeader = parameters
+            ? getOperationExplicitAcceptHeader(parameters.parametersHeader)
+            : getOperationImplicitAcceptHeader(operationResults);
         if (acceptHeader) {
-                const acceptHeaderOperationParameter: OperationParameter = {
-                    in: 'header',
-                    prop: 'Accept',
-                    export: 'interface',
-                    name: `'${acceptHeader}'`,
-                    type: 'any',
-                    base: 'any',
-                    template: null,
-                    link: null,
-                    description: null,
-                    isDefinition: false,
-                    isReadOnly: false,
-                    isRequired: true,
-                    isNullable: false,
-                    imports: [],
-                    enum: [],
-                    enums: [],
-                    properties: [],
-                    mediaType: null,
-                };
-                operation.parametersHeader.push(acceptHeaderOperationParameter);
-            }
+            const acceptHeaderOperationParameter: OperationParameter = {
+                in: 'header',
+                prop: 'Accept',
+                export: 'interface',
+                name: `'${acceptHeader}'`,
+                type: 'any',
+                base: 'any',
+                template: null,
+                link: null,
+                description: null,
+                isDefinition: false,
+                isReadOnly: false,
+                isRequired: true,
+                isNullable: false,
+                imports: [],
+                enum: [],
+                enums: [],
+                properties: [],
+                mediaType: null,
+            };
+            operation.parametersHeader.push(acceptHeaderOperationParameter);
         }
 
         operationResults.forEach(operationResult => {

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -134,6 +134,7 @@ export const getOperation = (
         // Add 'Accept' header, if not set
         const explicitAcceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : null;
         if (!explicitAcceptHeader) {
+            // if `explicitAcceptHeader` exists, there's no need to add it
             const acceptHeader = getOperationImplicitAcceptHeader(operationResults);
             if (acceptHeader) {
                 const acceptHeaderOperationParameter: OperationParameter = {

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -132,10 +132,8 @@ export const getOperation = (
         operation.responseType = getOperationResponseType(operationResults);
 
         // Add 'Accept' header, if not set
-        const explicitAcceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : null;
-        if (!explicitAcceptHeader) {
-            const acceptHeader = getOperationImplicitAcceptHeader(operationResults);
-            if (acceptHeader) {
+        const acceptHeader = parameters ? getOperationExplicitAcceptHeader(parameters.parametersHeader) : getOperationImplicitAcceptHeader(operationResults);
+        if (acceptHeader) {
                 const acceptHeaderOperationParameter: OperationParameter = {
                     in: 'header',
                     prop: 'Accept',

--- a/src/openApi/v3/parser/getOperationExplicitAcceptHeader.ts
+++ b/src/openApi/v3/parser/getOperationExplicitAcceptHeader.ts
@@ -4,8 +4,5 @@ export const getOperationExplicitAcceptHeader = (operationParameters: OperationP
     const header = operationParameters.find(operationParameter => {
         return operationParameter.in === 'header' && operationParameter.name.toLowerCase() === 'accept';
     });
-    if (header) {
-        return header.name;
-    }
-    return null;
+    return header ? header.name : null;
 };

--- a/src/openApi/v3/parser/getOperationExplicitAcceptHeader.ts
+++ b/src/openApi/v3/parser/getOperationExplicitAcceptHeader.ts
@@ -1,0 +1,11 @@
+import type { OperationParameter } from '../../../client/interfaces/OperationParameter';
+
+export const getOperationExplicitAcceptHeader = (operationParameters: OperationParameter[]): string | null => {
+    const header = operationParameters.find(operationParameter => {
+        return operationParameter.in === 'header' && operationParameter.name.toLowerCase() === 'accept';
+    });
+    if (header) {
+        return header.name;
+    }
+    return null;
+};

--- a/src/openApi/v3/parser/getOperationImplicitAcceptHeader.ts
+++ b/src/openApi/v3/parser/getOperationImplicitAcceptHeader.ts
@@ -4,8 +4,5 @@ export const getOperationImplicitAcceptHeader = (operationResponses: OperationRe
     const operationResponse = operationResponses.find(operationResponses => {
         return operationResponses.in === 'response';
     });
-    if (operationResponse) {
-        return operationResponse.mediaType;
-    }
-    return null;
+    return operationResponse ? operationResponse.mediaType : null;
 };

--- a/src/openApi/v3/parser/getOperationImplicitAcceptHeader.ts
+++ b/src/openApi/v3/parser/getOperationImplicitAcceptHeader.ts
@@ -1,0 +1,11 @@
+import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
+
+export const getOperationImplicitAcceptHeader = (operationResponses: OperationResponse[]): string | null => {
+    const operationResponse = operationResponses.find(operationResponses => {
+        return operationResponses.in === 'response';
+    });
+    if (operationResponse) {
+        return operationResponse.mediaType;
+    }
+    return null;
+};

--- a/src/openApi/v3/parser/getOperationResponse.ts
+++ b/src/openApi/v3/parser/getOperationResponse.ts
@@ -31,11 +31,13 @@ export const getOperationResponse = (
         enum: [],
         enums: [],
         properties: [],
+        mediaType: null,
     };
 
     if (response.content) {
         const content = getContent(openApi, response.content);
         if (content) {
+            operationResponse.mediaType = content.mediaType;
             if (content.schema.$ref?.startsWith('#/components/responses/')) {
                 content.schema = getRef<OpenApiSchema>(openApi, content.schema);
             }

--- a/src/openApi/v3/parser/getOperationResponseType.ts
+++ b/src/openApi/v3/parser/getOperationResponseType.ts
@@ -1,0 +1,13 @@
+import type { OperationResponse } from '../../../client/interfaces/OperationResponse';
+
+export const getOperationResponseType = (
+    operationResponses: OperationResponse[]
+): 'arraybuffer' | 'document' | 'json' | 'text' | 'stream' | 'blob' | null => {
+    const operationResponse = operationResponses.find(operationResponses => {
+        return operationResponses.in === 'response';
+    });
+    if (operationResponse) {
+        return operationResponse.format === 'binary' ? 'blob' : null; // Other cases: not implemented
+    }
+    return null;
+};

--- a/src/openApi/v3/parser/getOperationResults.ts
+++ b/src/openApi/v3/parser/getOperationResults.ts
@@ -39,6 +39,7 @@ export const getOperationResults = (operationResponses: OperationResponse[]): Op
             enum: [],
             enums: [],
             properties: [],
+            mediaType: null,
         });
     }
 

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -163,6 +163,9 @@ export abstract class {{{name}}}{{{@root.postfix}}} {
 			{{#if responseHeader}}
 			responseHeader: '{{{responseHeader}}}',
 			{{/if}}
+			{{#if responseType}}
+			responseType: '{{{responseType}}}',
+			{{/if}}
 			{{#if errors}}
 			errors: {
 				{{#each errors}}

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -9375,6 +9375,9 @@ export abstract class ComplexService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
+            headers: {
+                'Accept': 'application/json',
+            },
             query: {
                 'parameterObject': data?.parameterObject,
                 'parameterReference': data?.parameterReference,
@@ -9419,6 +9422,9 @@ export abstract class ComplexService {
             url: '/api/v{api-version}/complex/{id}',
             path: {
                 'id': id,
+            },
+            headers: {
+                'Accept': 'application/json; type=collection',
             },
             body: {
                 'key': data?.key,
@@ -10710,7 +10716,6 @@ export abstract class PdfService {
             url: '/api/v{api-version}/pdf',
             headers: {
                 'Accept': accept,
-                'Accept': 'accept',
             },
             responseType: 'blob',
             errors: {
@@ -11117,6 +11122,9 @@ export abstract class TypesService {
             path: {
                 'id': id,
             },
+            headers: {
+                'Accept': 'application/json',
+            },
             query: {
                 'parameterNumber': data?.parameterNumber,
                 'parameterString': data?.parameterString,
@@ -11172,6 +11180,9 @@ export abstract class UploadService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/upload',
+            headers: {
+                'Accept': 'application/json',
+            },
             formData: {
                 'file': file,
             },

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3343,7 +3343,6 @@ export abstract class CollectionFormatService {
                 'parameterArrayPipes': data?.parameterArrayPipes,
                 'parameterArrayMulti': data?.parameterArrayMulti,
             },
-            responseType: 'json',
         });
     }
 
@@ -3411,7 +3410,6 @@ export abstract class ComplexService {
                 'parameterObject': data?.parameterObject,
                 'parameterReference': data?.parameterReference,
             },
-            responseType: 'json',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -3459,7 +3457,6 @@ export abstract class DefaultService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
-            responseType: 'json',
         });
     }
 
@@ -3535,7 +3532,6 @@ export abstract class DefaultsService {
                 'parameterEnum': data?.parameterEnum,
                 'parameterModel': data?.parameterModel,
             },
-            responseType: 'json',
         });
     }
 
@@ -3583,7 +3579,6 @@ export abstract class DefaultsService {
                 'parameterEnum': data?.parameterEnum,
                 'parameterModel': data?.parameterModel,
             },
-            responseType: 'json',
         });
     }
 
@@ -3646,7 +3641,6 @@ export abstract class DefaultsService {
                 'parameterStringNullableWithNoDefault': data?.parameterStringNullableWithNoDefault,
                 'parameterStringNullableWithDefault': data?.parameterStringNullableWithDefault,
             },
-            responseType: 'json',
         });
     }
 
@@ -3728,7 +3722,6 @@ export abstract class DescriptionsService {
                 'parameterWithQuotes': data?.parameterWithQuotes,
                 'parameterWithReservedCharacters': data?.parameterWithReservedCharacters,
             },
-            responseType: 'json',
         });
     }
 
@@ -3772,7 +3765,6 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
-            responseType: 'json',
         });
     }
 
@@ -3790,7 +3782,6 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
-            responseType: 'json',
         });
     }
 
@@ -3808,7 +3799,6 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
-            responseType: 'json',
         });
     }
 
@@ -3826,7 +3816,6 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
-            responseType: 'json',
         });
     }
 
@@ -3881,7 +3870,6 @@ export abstract class ErrorService {
             query: {
                 'status': data?.status,
             },
-            responseType: 'json',
             errors: {
                 500: \`Custom message: Internal Server Error\`,
                 501: \`Custom message: Not Implemented\`,
@@ -3933,7 +3921,6 @@ export abstract class HeaderService {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
-            responseType: 'json',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -3982,7 +3969,6 @@ export abstract class MultipleTags1Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
-            responseType: 'json',
         });
     }
 
@@ -4001,7 +3987,6 @@ export abstract class MultipleTags1Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
-            responseType: 'json',
         });
     }
 
@@ -4046,7 +4031,6 @@ export abstract class MultipleTags2Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
-            responseType: 'json',
         });
     }
 
@@ -4065,7 +4049,6 @@ export abstract class MultipleTags2Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
-            responseType: 'json',
         });
     }
 
@@ -4110,7 +4093,6 @@ export abstract class MultipleTags3Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
-            responseType: 'json',
         });
     }
 
@@ -4155,7 +4137,6 @@ export abstract class NoContentService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
-            responseType: 'json',
         });
     }
 
@@ -4227,7 +4208,6 @@ export abstract class ParametersService {
                 'parameterForm': parameterForm,
             },
             body: data?.parameterBody,
-            responseType: 'json',
         });
     }
 
@@ -4284,7 +4264,6 @@ export abstract class ParametersService {
                 'parameter_form': parameterForm,
             },
             body: data?.parameterBody,
-            responseType: 'json',
         });
     }
 
@@ -4333,7 +4312,6 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/response',
-            responseType: 'json',
         });
     }
 
@@ -4352,7 +4330,6 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/response',
-            responseType: 'json',
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -4383,7 +4360,6 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
-            responseType: 'json',
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -4432,7 +4408,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4450,7 +4425,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4468,7 +4442,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4486,7 +4459,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4504,7 +4476,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4522,7 +4493,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4540,7 +4510,6 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
-            responseType: 'json',
         });
     }
 
@@ -4633,7 +4602,6 @@ export abstract class TypesService {
                 'parameterDictionary': data?.parameterDictionary,
                 'parameterEnum': data?.parameterEnum,
             },
-            responseType: 'json',
         });
     }
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -3343,6 +3343,7 @@ export abstract class CollectionFormatService {
                 'parameterArrayPipes': data?.parameterArrayPipes,
                 'parameterArrayMulti': data?.parameterArrayMulti,
             },
+            responseType: 'json',
         });
     }
 
@@ -3410,6 +3411,7 @@ export abstract class ComplexService {
                 'parameterObject': data?.parameterObject,
                 'parameterReference': data?.parameterReference,
             },
+            responseType: 'json',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -3457,6 +3459,7 @@ export abstract class DefaultService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-tag',
+            responseType: 'json',
         });
     }
 
@@ -3532,6 +3535,7 @@ export abstract class DefaultsService {
                 'parameterEnum': data?.parameterEnum,
                 'parameterModel': data?.parameterModel,
             },
+            responseType: 'json',
         });
     }
 
@@ -3579,6 +3583,7 @@ export abstract class DefaultsService {
                 'parameterEnum': data?.parameterEnum,
                 'parameterModel': data?.parameterModel,
             },
+            responseType: 'json',
         });
     }
 
@@ -3641,6 +3646,7 @@ export abstract class DefaultsService {
                 'parameterStringNullableWithNoDefault': data?.parameterStringNullableWithNoDefault,
                 'parameterStringNullableWithDefault': data?.parameterStringNullableWithDefault,
             },
+            responseType: 'json',
         });
     }
 
@@ -3722,6 +3728,7 @@ export abstract class DescriptionsService {
                 'parameterWithQuotes': data?.parameterWithQuotes,
                 'parameterWithReservedCharacters': data?.parameterWithReservedCharacters,
             },
+            responseType: 'json',
         });
     }
 
@@ -3765,6 +3772,7 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/duplicate',
+            responseType: 'json',
         });
     }
 
@@ -3782,6 +3790,7 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/duplicate',
+            responseType: 'json',
         });
     }
 
@@ -3799,6 +3808,7 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/duplicate',
+            responseType: 'json',
         });
     }
 
@@ -3816,6 +3826,7 @@ export abstract class DuplicateService {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/duplicate',
+            responseType: 'json',
         });
     }
 
@@ -3870,6 +3881,7 @@ export abstract class ErrorService {
             query: {
                 'status': data?.status,
             },
+            responseType: 'json',
             errors: {
                 500: \`Custom message: Internal Server Error\`,
                 501: \`Custom message: Not Implemented\`,
@@ -3921,6 +3933,7 @@ export abstract class HeaderService {
             method: 'POST',
             url: '/api/v{api-version}/header',
             responseHeader: 'operation-location',
+            responseType: 'json',
             errors: {
                 400: \`400 server error\`,
                 500: \`500 server error\`,
@@ -3969,6 +3982,7 @@ export abstract class MultipleTags1Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
+            responseType: 'json',
         });
     }
 
@@ -3987,6 +4001,7 @@ export abstract class MultipleTags1Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
+            responseType: 'json',
         });
     }
 
@@ -4031,6 +4046,7 @@ export abstract class MultipleTags2Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/a',
+            responseType: 'json',
         });
     }
 
@@ -4049,6 +4065,7 @@ export abstract class MultipleTags2Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
+            responseType: 'json',
         });
     }
 
@@ -4093,6 +4110,7 @@ export abstract class MultipleTags3Service {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multiple-tags/b',
+            responseType: 'json',
         });
     }
 
@@ -4137,6 +4155,7 @@ export abstract class NoContentService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/no-content',
+            responseType: 'json',
         });
     }
 
@@ -4208,6 +4227,7 @@ export abstract class ParametersService {
                 'parameterForm': parameterForm,
             },
             body: data?.parameterBody,
+            responseType: 'json',
         });
     }
 
@@ -4264,6 +4284,7 @@ export abstract class ParametersService {
                 'parameter_form': parameterForm,
             },
             body: data?.parameterBody,
+            responseType: 'json',
         });
     }
 
@@ -4312,6 +4333,7 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/response',
+            responseType: 'json',
         });
     }
 
@@ -4330,6 +4352,7 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/response',
+            responseType: 'json',
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -4360,6 +4383,7 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
+            responseType: 'json',
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -4408,6 +4432,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4425,6 +4450,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4442,6 +4468,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4459,6 +4486,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'DELETE',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4476,6 +4504,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'OPTIONS',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4493,6 +4522,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'HEAD',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4510,6 +4540,7 @@ export abstract class SimpleService {
         return __request(this.client, this.config, options || {}, {
             method: 'PATCH',
             url: '/api/v{api-version}/simple',
+            responseType: 'json',
         });
     }
 
@@ -4602,6 +4633,7 @@ export abstract class TypesService {
                 'parameterDictionary': data?.parameterDictionary,
                 'parameterEnum': data?.parameterEnum,
             },
+            responseType: 'json',
         });
     }
 
@@ -5363,6 +5395,7 @@ export { MultipleTags3Service } from './services/MultipleTags3Service.js';
 export { NoContentService } from './services/NoContentService.js';
 export { OneOfService } from './services/OneOfService.js';
 export { ParametersService } from './services/ParametersService.js';
+export { PdfService } from './services/PdfService.js';
 export { RequestBodyService } from './services/RequestBodyService.js';
 export { ResponseService } from './services/ResponseService.js';
 export { SimpleService } from './services/SimpleService.js';
@@ -5406,6 +5439,7 @@ import { MultipleTags3Service } from './services/MultipleTags3Service.js';
 import { NoContentService } from './services/NoContentService.js';
 import { OneOfService } from './services/OneOfService.js';
 import { ParametersService } from './services/ParametersService.js';
+import { PdfService } from './services/PdfService.js';
 import { RequestBodyService } from './services/RequestBodyService.js';
 import { ResponseService } from './services/ResponseService.js';
 import { SimpleService } from './services/SimpleService.js';
@@ -5503,6 +5537,7 @@ applyMixins(LuneClient, [
     NoContentService,
     OneOfService,
     ParametersService,
+    PdfService,
     RequestBodyService,
     ResponseService,
     SimpleService,
@@ -5528,6 +5563,7 @@ export interface LuneClient extends
         NoContentService,
         OneOfService,
         ParametersService,
+        PdfService,
         RequestBodyService,
         ResponseService,
         SimpleService,
@@ -5623,6 +5659,7 @@ export { MultipleTags3Service } from './services/MultipleTags3Service.js';
 export { NoContentService } from './services/NoContentService.js';
 export { OneOfService } from './services/OneOfService.js';
 export { ParametersService } from './services/ParametersService.js';
+export { PdfService } from './services/PdfService.js';
 export { RequestBodyService } from './services/RequestBodyService.js';
 export { ResponseService } from './services/ResponseService.js';
 export { SimpleService } from './services/SimpleService.js';
@@ -9370,6 +9407,9 @@ export abstract class ComplexService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
+            headers: {
+                'Accept': 'application/json',
+            },
             query: {
                 'parameterObject': data?.parameterObject,
                 'parameterReference': data?.parameterReference,
@@ -9414,6 +9454,9 @@ export abstract class ComplexService {
             url: '/api/v{api-version}/complex/{id}',
             path: {
                 'id': id,
+            },
+            headers: {
+                'Accept': 'application/json; type=collection',
             },
             body: {
                 'key': data?.key,
@@ -10134,6 +10177,9 @@ export abstract class MultipartService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/multipart',
+            headers: {
+                'Accept': 'multipart/mixed',
+            },
         });
     }
 
@@ -10635,6 +10681,84 @@ export abstract class ParametersService {
 }"
 `;
 
+exports[`v3 should generate: ./test/generated/v3/services/PdfService.ts 1`] = `
+"// =========================================================================================
+//
+// This file is AUTO-GENERATED by https://github.com/lune-climate/openapi-typescript-codegen
+//
+// In most cases you DON'T WANT TO MAKE MANUAL CHANGES to it – they WILL BE OVERWRITTEN.
+//
+// =========================================================================================
+
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import { ClientConfig } from '../core/ClientConfig.js'
+import { request as __request } from '../core/request.js'
+import { SuccessResponse } from '../core/SuccessResponse.js'
+import { ApiError } from '../core/ApiError.js'
+import { AxiosInstance } from 'axios'
+import { Result } from 'ts-results-es'
+
+export abstract class PdfService {
+    protected abstract client: AxiosInstance
+    protected abstract config: ClientConfig
+
+    /**
+     * @param options Additional operation options
+     * @returns binary Message for 200 response
+     */
+    public getPdfResponse(
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<SuccessResponse<Blob>, ApiError>> {
+        return __request(this.client, this.config, options || {}, {
+            method: 'GET',
+            url: '/api/v{api-version}/pdf',
+            headers: {
+                'Accept': 'application/pdf',
+            },
+            responseType: 'blob',
+            errors: {
+                404: \`Message for 404 response\`,
+            },
+        });
+    }
+
+    /**
+     * @param accept Accept parameter should not be overwritten
+     * @param options Additional operation options
+     * @returns binary Message for 200 response
+     */
+    public pdfResponseWithExplicitAcceptHeader(
+        accept: string | null,
+        options?: {
+            /**
+             * Account Id to be used to perform the API call
+             */
+            accountId?: string;
+        },
+    ): Promise<Result<SuccessResponse<Blob>, ApiError>> {
+        return __request(this.client, this.config, options || {}, {
+            method: 'POST',
+            url: '/api/v{api-version}/pdf',
+            headers: {
+                'Accept': accept,
+            },
+            responseType: 'blob',
+            errors: {
+                404: \`Message for 404 response\`,
+            },
+        });
+    }
+
+}"
+`;
+
 exports[`v3 should generate: ./test/generated/v3/services/RequestBodyService.ts 1`] = `
 "// =========================================================================================
 //
@@ -10738,6 +10862,9 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/response',
+            headers: {
+                'Accept': 'application/json',
+            },
         });
     }
 
@@ -10756,6 +10883,9 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/response',
+            headers: {
+                'Accept': 'application/json',
+            },
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -10786,6 +10916,9 @@ export abstract class ResponseService {
         return __request(this.client, this.config, options || {}, {
             method: 'PUT',
             url: '/api/v{api-version}/response',
+            headers: {
+                'Accept': 'application/json',
+            },
             errors: {
                 500: \`Message for 500 error\`,
                 501: \`Message for 501 error\`,
@@ -11021,6 +11154,9 @@ export abstract class TypesService {
             path: {
                 'id': id,
             },
+            headers: {
+                'Accept': 'application/json',
+            },
             query: {
                 'parameterNumber': data?.parameterNumber,
                 'parameterString': data?.parameterString,
@@ -11076,6 +11212,9 @@ export abstract class UploadService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/upload',
+            headers: {
+                'Accept': 'application/json',
+            },
             formData: {
                 'file': file,
             },

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -9375,9 +9375,6 @@ export abstract class ComplexService {
         return __request(this.client, this.config, options || {}, {
             method: 'GET',
             url: '/api/v{api-version}/complex',
-            headers: {
-                'Accept': 'application/json',
-            },
             query: {
                 'parameterObject': data?.parameterObject,
                 'parameterReference': data?.parameterReference,
@@ -9422,9 +9419,6 @@ export abstract class ComplexService {
             url: '/api/v{api-version}/complex/{id}',
             path: {
                 'id': id,
-            },
-            headers: {
-                'Accept': 'application/json; type=collection',
             },
             body: {
                 'key': data?.key,
@@ -10716,6 +10710,7 @@ export abstract class PdfService {
             url: '/api/v{api-version}/pdf',
             headers: {
                 'Accept': accept,
+                'Accept': 'accept',
             },
             responseType: 'blob',
             errors: {
@@ -11122,9 +11117,6 @@ export abstract class TypesService {
             path: {
                 'id': id,
             },
-            headers: {
-                'Accept': 'application/json',
-            },
             query: {
                 'parameterNumber': data?.parameterNumber,
                 'parameterString': data?.parameterString,
@@ -11180,9 +11172,6 @@ export abstract class UploadService {
         return __request(this.client, this.config, options || {}, {
             method: 'POST',
             url: '/api/v{api-version}/upload',
-            headers: {
-                'Accept': 'application/json',
-            },
             formData: {
                 'file': file,
             },

--- a/test/spec/v3.json
+++ b/test/spec/v3.json
@@ -1501,6 +1501,78 @@
                     }
                 }
             }
+        },
+        "/api/v{api-version}/pdf": {
+            "get": {
+                "tags": [
+                    "pdf"
+                ],
+                "operationId": "GetPdfResponse",
+                "responses": {
+                    "404": {
+                        "description": "Message for 404 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ModelWithString"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Message for 200 response",
+                        "content": {
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "pdf"
+                ],
+                "operationId": "PdfResponseWithExplicitAcceptHeader",
+                "parameters": [
+                    {
+                        "description": "Accept parameter should not be overwritten",
+                        "name": "Accept",
+                        "in": "header",
+                        "required": true,
+                        "nullable": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "404": {
+                        "description": "Message for 404 response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ModelWithString"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Message for 200 response",
+                        "content": {
+                            "application/pdf": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {


### PR DESCRIPTION
By default this library adds a `Accept: application/json` header to requests.
We want to signal that other content types are accepted also, eg 'application/pdf'.

Furthermore, Axios won't handle binary response data without the `responseType` parameter set to something other than `json` (which is the default).

Therefore, this library now set both a non-`Accept: application/json` header (if one is not explicit defined in the spec) and `responseType: arraybuffer` parameter for binary responses.

See https://axios-http.com/docs/req_config.